### PR TITLE
Adds a simple GradientView (wrapping CAGradientLayer)

### DIFF
--- a/WordPressUI.xcodeproj/project.pbxproj
+++ b/WordPressUI.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		17576E6320AC7A28008612EF /* GradientView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17576E6220AC7A28008612EF /* GradientView.swift */; };
 		43067E2B203C8CC4001DD610 /* UIControl+BlockEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43067E2A203C8CC4001DD610 /* UIControl+BlockEvents.swift */; };
 		43067E2E203C8D03001DD610 /* UIBarButtonItem+BlockEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43067E2D203C8D03001DD610 /* UIBarButtonItem+BlockEvents.swift */; };
 		43067E30203C8D27001DD610 /* UIGestureRecognizer+BlockEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43067E2F203C8D27001DD610 /* UIGestureRecognizer+BlockEvents.swift */; };
@@ -67,6 +68,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		17576E6220AC7A28008612EF /* GradientView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradientView.swift; sourceTree = "<group>"; };
 		43067E2A203C8CC4001DD610 /* UIControl+BlockEvents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIControl+BlockEvents.swift"; sourceTree = "<group>"; };
 		43067E2D203C8D03001DD610 /* UIBarButtonItem+BlockEvents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIBarButtonItem+BlockEvents.swift"; sourceTree = "<group>"; };
 		43067E2F203C8D27001DD610 /* UIGestureRecognizer+BlockEvents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIGestureRecognizer+BlockEvents.swift"; sourceTree = "<group>"; };
@@ -170,6 +172,7 @@
 			isa = PBXGroup;
 			children = (
 				B5393FE9206D7047007BF9D4 /* RotationAwareNavigationViewController.swift */,
+				17576E6220AC7A28008612EF /* GradientView.swift */,
 			);
 			path = Tools;
 			sourceTree = "<group>";
@@ -450,6 +453,7 @@
 				B5A787E1202B2B59007874FB /* UIControl+Helpers.swift in Sources */,
 				B518D76720740F0800F05DB4 /* UIImageView+Blavatar.swift in Sources */,
 				43067E2E203C8D03001DD610 /* UIBarButtonItem+BlockEvents.swift in Sources */,
+				17576E6320AC7A28008612EF /* GradientView.swift in Sources */,
 				B592B4522064296600FF568E /* FancyAlertViewController.swift in Sources */,
 				B58C4EBC207C55D300E32E4D /* UIImage+Assets.swift in Sources */,
 				B5A787F5202B3587007874FB /* UIKitConstants.swift in Sources */,

--- a/WordPressUI/Tools/GradientView.swift
+++ b/WordPressUI/Tools/GradientView.swift
@@ -1,0 +1,88 @@
+import UIKit
+
+/// A simple UIView subclass that displays a gradient.
+/// Gradient colors and positioning can be set in code via properties
+/// or in Interface Builder.
+///
+@IBDesignable
+class GradientView: UIView {
+    private let gradientLayer = CAGradientLayer()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        commonInit()
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        commonInit()
+    }
+
+    private func commonInit() {
+        layer.addSublayer(gradientLayer)
+
+        updateGradientFrame()
+        updateGradientColors()
+        updateGradientPoints()
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        updateGradientFrame()
+    }
+
+    // MARK: - Inspectable appearance properties
+
+    @IBInspectable
+    var fromColor: UIColor = Defaults.whiteColor {
+        didSet {
+            updateGradientColors()
+        }
+    }
+
+    @IBInspectable
+    var toColor: UIColor =  Defaults.clearColor {
+        didSet {
+            updateGradientColors()
+        }
+    }
+
+    /// Matches CAGradientLayer's startPoint
+    @IBInspectable
+    var startPoint: CGPoint = Defaults.startPoint {
+        didSet {
+            updateGradientPoints()
+        }
+    }
+
+    /// Matches CAGradientLayer's endPoint
+    @IBInspectable
+    var endPoint: CGPoint = Defaults.endPoint {
+        didSet {
+            updateGradientPoints()
+        }
+    }
+
+    private func updateGradientFrame() {
+        gradientLayer.frame = bounds
+    }
+
+    private func updateGradientColors() {
+        gradientLayer.colors = [fromColor.cgColor, toColor.cgColor]
+    }
+
+    private func updateGradientPoints() {
+        gradientLayer.startPoint = startPoint
+        gradientLayer.endPoint = endPoint
+    }
+
+    private enum Defaults {
+        // We need to use white and alpha to ensure we use the same
+        // colorspace when fading to a clear color.
+        static let whiteColor = UIColor(white: 1.0, alpha: 1.0)
+        static let clearColor = UIColor(white: 1.0, alpha: 0.0)
+        static let startPoint = CGPoint(x: 0.5, y: 0.0)
+        static let endPoint = CGPoint(x: 0.5, y: 1.0)
+    }
+}


### PR DESCRIPTION
This PR adds `GradientView` – a UIView subclass that wraps a CAGradientLayer. Starting and ending colors and positions for the gradient can be configured by properties or in Interface Builder via IBDesignables.

**To test:**

* Check that WordPressUI builds with no warnings / errors
* Check out this WordPress-iOS branch: `feature/move-reader-tags-ui`.
* Navigate to a Reader post detail view for a post with tags – the most recent posts on Discover all have tags.
* The gradient view is used in the byline section of the screen, to add a small gradient at the start and end of the byline when scrolling:

![simulator screen shot - iphone 8 - 2018-05-16 at 15 02 40](https://user-images.githubusercontent.com/4780/40125831-c119f49c-5923-11e8-902e-da49702232d1.png)
