### PR TITLE
Make sure previous download is canceled even if we go to cache.

### DIFF
--- a/WordPressUI/Extensions/UIImageView+Networking.swift
+++ b/WordPressUI/Extensions/UIImageView+Networking.swift
@@ -30,6 +30,24 @@ public extension UIImageView {
     ///     -   failure: Closure to be executed upon failure.
     ///
     public func downloadImage(from url: URL?, placeholderImage: UIImage? = nil, success: ((UIImage) -> ())? = nil, failure: ((Error?) -> ())? = nil) {
+        // Ideally speaking, this method should *not* receive an Optional URL. But we're doing so, for convenience.
+        // If the actual URL was nil, at least we set the Placeholder Image. Capicci?
+        guard let url = url else {
+            if let placeholderImage = placeholderImage {
+                image = placeholderImage
+            }
+            return
+        }
+
+        // If we are asking for the same URL let's just stay like we are
+        guard url != downloadURL else {
+            return
+        }
+
+        // Do this first, if there was any ongoing task for this imageview we need to cancel imediately or else we can apply the cache image and not cancel a previous download
+        downloadURL = url
+        downloadTask?.cancel()
+
         let internalOnSuccess = { [weak self] (image: UIImage) in
             self?.image = image
             success?(image)
@@ -39,15 +57,6 @@ public extension UIImageView {
             internalOnSuccess(cachedImage)
             return
         }
-
-        // Ideally speaking, this method should *not* receive an Optional URL. But we're doing so, for convenience.
-        // If the actual URL was nil, at least we set the Placeholder Image. Capicci?
-        //
-        guard let url = url, url != downloadURL else {
-            return
-        }
-
-        downloadURL = url
 
         if let placeholderImage = placeholderImage {
             image = placeholderImage

--- a/WordPressUI/Extensions/UIImageView+Networking.swift
+++ b/WordPressUI/Extensions/UIImageView+Networking.swift
@@ -36,6 +36,8 @@ public extension UIImageView {
             if let placeholderImage = placeholderImage {
                 image = placeholderImage
             }
+            downloadURL = nil
+            downloadTask?.cancel()
             return
         }
 


### PR DESCRIPTION
Related to: https://github.com/wordpress-mobile/WordPress-iOS/issues/9296

This PR changes the code on 'downloadImage' to make sure any pending previous download on the UIImageView is cancelled even when we use the cache.

This solves the problem when an image url is initially set with a value that triggers a network call, then followed up by another url that is set using the cache. When the network callback executed the cache image that was set after was replaced by the older value.
