### PR TITLE
UIImageView+Networking: Fix no return point.

### DIFF
--- a/WordPressUI/Extensions/UIImageView+Networking.swift
+++ b/WordPressUI/Extensions/UIImageView+Networking.swift
@@ -43,6 +43,9 @@ public extension UIImageView {
 
         // If we are asking for the same URL let's just stay like we are
         guard url != downloadURL else {
+            if let error = downloadTask?.error {
+                failure?(error)
+            }
             return
         }
 


### PR DESCRIPTION
This PR fixes an issue described [here](https://github.com/wordpress-mobile/WordPress-iOS/pull/9427#pullrequestreview-123300155) . 
> If I keep scrolling while still in airplane mode, some of the image views then switch into a loading state, even though they're not loading anything.

This happens because:
* When reusing cells, we always call `downloadImage` (for static ones).
* This triggers the loading state of the loading indicator.
* The loading indicator expect a success or an error to stop.
* When the download task finished with an error (in this case, no connection) ...
* If the reused cell is the same than before, the guard `guard url != downloadURL else {` will catch it.
* Since it used to just return, and the task is already finished, no success or error would be ever called.
* Loader spin forever

To fix this, we check if the download task has an error:
> var error: Error? { get }
An error object that indicates why the task failed.This value is NULL if the task is still active or if the transfer completed successfully.

And return it indicating that the task already finished with an error.

To test:
Check out this PR, and test that the issue is solved.
The easier way to reproduce it is:
* Scrolling fast in the reader.
* When you see images loading, set Airplane mode.
* Continue scrolling down and up.
* With the issue, you would see some loading indicator spinning.
