### PR TITLE
FancyAlertView: Make title accessory button constraint strong

### DIFF
--- a/WordPressUI/FancyAlert/FancyAlertView.swift
+++ b/WordPressUI/FancyAlert/FancyAlertView.swift
@@ -17,7 +17,7 @@ open class FancyAlertView: UIView {
     /// Title
     ///
     @IBOutlet weak var titleLabel: UILabel!
-    @IBOutlet weak var titleAccessoryButtonTrailingConstraint: NSLayoutConstraint!
+    @IBOutlet var titleAccessoryButtonTrailingConstraint: NSLayoutConstraint!
 
     /// Body
     ///


### PR DESCRIPTION
This PR introduces the same fix as https://github.com/wordpress-mobile/WordPress-iOS/pull/9471, but applied to WordPressUI now it's moved into a separate pod.

**To test:**

* Check out the `fix/fancy-alert-constraint` branch of WPiOS
* In WPiOS, update `needsEmailVerification` in `WPAccount` to `return true`
* Log in and open the editor, and add some text
* Tap Publish, then tap Resend on the alert that appears
* Without this patch, the app will crash. With the app, the fancy alert should transition to show new information and there should be no crash.
