### PR TITLE
FlingableViewHandler: Added weak to delegate

### DIFF
--- a/WordPressUI/FlingableView/FlingableViewHandler.swift
+++ b/WordPressUI/FlingableView/FlingableViewHandler.swift
@@ -27,7 +27,7 @@ open class FlingableViewHandler: NSObject {
         }
     }
 
-    @objc public var delegate: FlingableViewHandlerDelegate?
+    @objc public weak var delegate: FlingableViewHandlerDelegate?
 
     fileprivate let animator: UIDynamicAnimator
     fileprivate var attachmentBehavior: UIAttachmentBehavior!


### PR DESCRIPTION
This PR adds the `weak` attribute to the `FlingableViewHandler.delegate` property to avoid a retain cycle.

<img width="273" alt="screen shot 2018-06-01 at 8 27 57 pm" src="https://user-images.githubusercontent.com/9772967/40868394-735038d4-65da-11e8-9376-39a42bb46130.png">

<img width="450" alt="screen shot 2018-06-01 at 8 25 15 pm" src="https://user-images.githubusercontent.com/9772967/40868340-f5f620b0-65d9-11e8-9805-b50f9b3b084b.png">

@jleandroperez Could you please take a look? Thank you!
