### PR TITLE
UIImageView+Networking: Added missing success call

### DIFF
--- a/WordPressUI/Extensions/UIImageView+Networking.swift
+++ b/WordPressUI/Extensions/UIImageView+Networking.swift
@@ -41,10 +41,20 @@ public extension UIImageView {
             return
         }
 
+        let internalOnSuccess = { [weak self] (image: UIImage) in
+            self?.image = image
+            success?(image)
+        }
+
+        let cachedImage = Downloader.cache.object(forKey: url as AnyObject) as? UIImage
+
         // If we are asking for the same URL let's just stay like we are
         guard url != downloadURL else {
             if let error = downloadTask?.error {
                 failure?(error)
+            }
+            if let image = cachedImage {
+                internalOnSuccess(image)
             }
             return
         }
@@ -53,13 +63,8 @@ public extension UIImageView {
         downloadURL = url
         downloadTask?.cancel()
 
-        let internalOnSuccess = { [weak self] (image: UIImage) in
-            self?.image = image
-            success?(image)
-        }
-
-        if let cachedImage = Downloader.cache.object(forKey: url as AnyObject) as? UIImage {
-            internalOnSuccess(cachedImage)
+        if let image = cachedImage {
+            internalOnSuccess(image)
             return
         }
 

--- a/WordPressUI/Extensions/UIImageView+Networking.swift
+++ b/WordPressUI/Extensions/UIImageView+Networking.swift
@@ -49,10 +49,7 @@ public extension UIImageView {
         let cachedImage = Downloader.cache.object(forKey: url as AnyObject) as? UIImage
 
         // If we are asking for the same URL let's just stay like we are
-        guard url != downloadURL else {
-            if let error = downloadTask?.error {
-                failure?(error)
-            }
+        guard url != downloadURL || taskFinishedWitherror() else {
             if let image = cachedImage {
                 internalOnSuccess(image)
             }
@@ -111,6 +108,12 @@ public extension UIImageView {
         URLSession.shared.configuration.urlCache?.removeAllCachedResponses()
     }
 
+
+    /// Returns true if the task finished with an error.
+    ///
+    private func taskFinishedWitherror() -> Bool {
+        return downloadTask?.error != nil
+    }
 
     /// Returns a URLRequest for an image, hosted at the specified URL.
     ///


### PR DESCRIPTION
Similar to #4 , there is another "no return point" when:

1. The url loading is the same than it was loading before.
2. The image was successfully downloaded.

This created the effect of showing the image and then changing to a infinite loading state.
This is easily reproducible having just one post with featured image in the post list.

![loading_issue](https://user-images.githubusercontent.com/9772967/40887773-2590cbc4-6713-11e8-95d2-00244665ee10.gif)

This PR fixes this issue by:
- Getting a 'possible' cached image for the given url
- Checking if the url given is the same than before
- If that cached image exist, we can assume that the image was successfully downloaded previously
- Call the success block.

To test:
- Be sure to have just one post, and that post with a feature image.
- Open the post list and let the image load.
- Go back and open again the post list.
- Check that the image remains visible.


@SergioEstevao could you please take a look? Thank you!