### PR TITLE
Fix/fancy button default corner radius

### DIFF
--- a/WordPressUI/Extensions/UIImage+Assets.swift
+++ b/WordPressUI/Extensions/UIImage+Assets.swift
@@ -80,7 +80,7 @@ extension UIImage {
     ///
     public struct DefaultRenderMetrics {
         public static let backgroundImageSize = CGSize(width: 44, height: 44)
-        public static let backgroundCornerRadius = CGFloat(7)
+        public static let backgroundCornerRadius = CGFloat(8)
         public static let backgroundCapInsets = UIEdgeInsets(top: 18, left: 18, bottom: 18, right: 18)
         public static let backgroundShadowOffset = CGSize(width: 0, height: 1)
         public static let backgroundShadowBlurRadius = CGFloat(0)

--- a/WordPressUI/Extensions/UIImage+Assets.swift
+++ b/WordPressUI/Extensions/UIImage+Assets.swift
@@ -82,7 +82,7 @@ extension UIImage {
         public static let backgroundImageSize = CGSize(width: 44, height: 44)
         public static let backgroundCornerRadius = CGFloat(8)
         public static let backgroundCapInsets = UIEdgeInsets(top: 18, left: 18, bottom: 18, right: 18)
-        public static let backgroundShadowOffset = CGSize(width: 0, height: 1)
+        public static let backgroundShadowOffset = CGSize(width: 0, height: 2)
         public static let backgroundShadowBlurRadius = CGFloat(0)
         public static let contentInsets = UIEdgeInsets(top: 12, left: 20, bottom: 12, right: 20)
     }


### PR DESCRIPTION
This PR updates the default settings for `FancyButton` and `NUXButton`, cornerRadius of 8 and shadow offset height of 2. 

To test the changes, see https://github.com/wordpress-mobile/WordPress-iOS/pull/9714