### PR TITLE
Add cache-breaking gravatar notification

### DIFF
--- a/WordPressUI/Extensions/UIImageView+Gravatar.swift
+++ b/WordPressUI/Extensions/UIImageView+Gravatar.swift
@@ -194,8 +194,12 @@ extension UIImageView {
     /// Returns the required gravatar size. If the current view's size is zero, falls back to the default size.
     ///
     private func gravatarDefaultSize() -> Int {
-        let targetSize = Defaults.imageSize * Int(UIScreen.main.scale)
-        return targetSize
+        guard bounds.size.equalTo(.zero) == false else {
+            return Defaults.imageSize
+        }
+
+        let targetSize = max(bounds.width, bounds.height) * UIScreen.main.scale
+        return Int(targetSize)
     }
 
     /// Private helper structure: contains the default Gravatar parameters

--- a/WordPressUI/Extensions/UIImageView+Gravatar.swift
+++ b/WordPressUI/Extensions/UIImageView+Gravatar.swift
@@ -66,8 +66,8 @@ extension UIImageView {
 
         gravatarObserver = NotificationCenter.default.addObserver(forName: .GravatarImageUpdateNotification, object: nil, queue: nil) { [weak self] (notification) in
             guard let userInfo = notification.userInfo,
-                let email = userInfo["email"] as? String,
-                let image = userInfo["image"] as? UIImage,
+                let email = userInfo[Defaults.emailKey] as? String,
+                let image = userInfo[Defaults.imageKey] as? UIImage,
                 let downloadURL = self?.downloadURL else {
                 return
             }
@@ -173,7 +173,7 @@ extension UIImageView {
         guard let email = email, let gravatarURL = gravatarUrl(for: email, size: Defaults.imageSize, rating: .x) else {
             return
         }
-        NotificationCenter.default.post(name: .GravatarImageUpdateNotification, object: self, userInfo: ["email": email, "image": image])
+        NotificationCenter.default.post(name: .GravatarImageUpdateNotification, object: self, userInfo: [Defaults.emailKey: email, Defaults.imageKey: image])
     }
 
 
@@ -225,6 +225,8 @@ extension UIImageView {
         static let imageSize = 80
         static let baseURL = "https://gravatar.com/avatar"
         static var gravatarObserverKey = "gravatarObserverKey"
+        static let emailKey = "email"
+        static let imageKey = "image"
     }
 }
 

--- a/WordPressUI/Extensions/UIImageView+Gravatar.swift
+++ b/WordPressUI/Extensions/UIImageView+Gravatar.swift
@@ -116,9 +116,15 @@ extension UIImageView {
         })
     }
 
+
     /// Sets an Image Override in both, AFNetworking's Private Cache + NSURLCache
     ///
-    /// Note I:
+    /// - Parameters:
+    ///   - image: new UIImage
+    ///   - rating: rating for the new image.
+    ///   - email: associated email of the new gravatar
+    /// - Note: You may want to use `updateGravatar(image:, email:)` instead
+    ///
     /// *WHY* is this required?. *WHY* life has to be so complicated?, is the universe against us?
     /// This has been implemented as a workaround. During Upload, we want any async calls made to the
     /// `downloadGravatar` API to return the "Fresh" image.
@@ -130,14 +136,6 @@ extension UIImageView {
     /// P.s.:
     /// Hope buddah, and the code reviewer, can forgive me for this hack.
     ///
-
-    /// Sets an Image Override in both, AFNetworking's Private Cache + NSURLCache
-    ///
-    /// - Parameters:
-    ///   - image: new UIImage
-    ///   - rating: rating for the new image.
-    ///   - email: associated email of the new gravatar
-    /// - Note: You may want to use `updateGravatar(image:, email:)` instead
     @available(*, deprecated)
     @objc public func overrideGravatarImageCache(_ image: UIImage, rating: GravatarRatings, email: String) {
         guard let gravatarURL = gravatarUrl(for: email, size: gravatarDefaultSize(), rating: rating) else {
@@ -179,7 +177,7 @@ extension UIImageView {
         return URL(string: targetURL)
     }
 
-    /// Returns the gravatar has of an email
+    /// Returns the gravatar hash of an email
     ///
     /// - Parameter email: the email associated with the gravatar
     /// - Returns: hashed email

--- a/WordPressUI/Extensions/UIImageView+Networking.swift
+++ b/WordPressUI/Extensions/UIImageView+Networking.swift
@@ -128,7 +128,7 @@ public extension UIImageView {
 
     /// Stores the Image's remote URL, if any.
     ///
-    private var downloadURL: URL? {
+    internal var downloadURL: URL? {
         get {
             return objc_getAssociatedObject(self, &Downloader.urlKey) as? URL
         }


### PR DESCRIPTION
This is the main changes to allow gravatar images to be updated in one place and take effect throughout the app.

Mostly: call `updateGravatar(image: UIImage, email: String?)` and it will post a `GravatarImageUpdateNotification` that all other UIImageViews displays the same gravatar will then display.

It's a bit of a hack, but it gets the job done and is _fairly_ easy to understand.