### PR TITLE
Refactor UIImageGravatar+Gravatar to no longer crash

### DIFF
--- a/WordPressUI.podspec
+++ b/WordPressUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressUI"
-  s.version       = "1.0.8"
+  s.version       = "1.0.9-beta.1"
   s.summary       = "Home of reusable WordPress UI components."
 
   s.description   = <<-DESC


### PR DESCRIPTION
Ok, let's see if this works better and less crashy:

Gravatar changes are still propagated with `NSNotification` but a wrapper is now used to remove the observer. @jleandroperez this is basically exactly as you suggested. How does it look?