### PR TITLE
Fix some warnings in the Gravatar code

### DIFF
--- a/WordPressUI/Extensions/UIImageView+Gravatar.swift
+++ b/WordPressUI/Extensions/UIImageView+Gravatar.swift
@@ -162,7 +162,6 @@ extension UIImageView {
     /// P.s.:
     /// Hope buddah, and the code reviewer, can forgive me for this hack.
     ///
-    @available(*, deprecated)
     @objc public func overrideGravatarImageCache(_ image: UIImage, rating: GravatarRatings, email: String) {
         guard let gravatarURL = gravatarUrl(for: email, size: gravatarDefaultSize(), rating: rating) else {
             return
@@ -179,7 +178,7 @@ extension UIImageView {
     ///   - email: associated email of the new gravatar
     @objc public func updateGravatar(image: UIImage, email: String?) {
         self.image = image
-        guard let email = email, let gravatarURL = gravatarUrl(for: email, size: Defaults.imageSize, rating: .x) else {
+        guard let email = email else {
             return
         }
         NotificationCenter.default.post(name: .GravatarImageUpdateNotification, object: self, userInfo: [Defaults.emailKey: email, Defaults.imageKey: image])


### PR DESCRIPTION
Yeah, this removes two warnings.

<img width="308" alt="image" src="https://user-images.githubusercontent.com/517257/45457191-b0aec100-b6a2-11e8-9f44-d4859ed1cf40.png">

and

<img width="930" alt="image" src="https://user-images.githubusercontent.com/517257/45457210-c15f3700-b6a2-11e8-800a-021a4669d8bd.png">


I'd love to add the `@available(*, deprecated)` back in, but I ought to wait until `WPiOS` is ready to remove that call, and it's a touch _complicated_.