### PR TITLE
Add a third button to FancyAlerts

### DIFF
--- a/WordPressUI.podspec
+++ b/WordPressUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressUI"
-  s.version       = "1.0.8-beta.2"
+  s.version       = "1.0.8-beta.3"
   s.summary       = "Home of reusable WordPress UI components."
 
   s.description   = <<-DESC

--- a/WordPressUI/FancyAlert/FancyAlertView.swift
+++ b/WordPressUI/FancyAlert/FancyAlertView.swift
@@ -32,6 +32,7 @@ open class FancyAlertView: UIView {
     ///
     @IBOutlet weak var cancelButton: UIButton!
     @IBOutlet weak var defaultButton: UIButton!
+    @IBOutlet weak var neverButton: UIButton!
     @IBOutlet weak var moreInfoButton: UIButton!
     @IBOutlet weak var titleAccessoryButton: UIButton!
 

--- a/WordPressUI/FancyAlert/FancyAlertViewController.swift
+++ b/WordPressUI/FancyAlert/FancyAlertViewController.swift
@@ -47,6 +47,9 @@ open class FancyAlertViewController: UIViewController {
         /// Title / handler for the de-emphasised cancel button on the dialog
         let cancelButton: ButtonConfig?
 
+        /// Title / handler for a second de-emphasised button on the dialog
+        let neverButton: ButtonConfig?
+
         /// Title / handler for a link-style button displayed beneath the body text
         let moreInfoButton: ButtonConfig?
 
@@ -67,6 +70,7 @@ open class FancyAlertViewController: UIViewController {
                     dividerPosition: DividerPosition?,
                     defaultButton: ButtonConfig?,
                     cancelButton: ButtonConfig?,
+                    neverButton: ButtonConfig? = nil,
                     moreInfoButton: ButtonConfig? = nil,
                     titleAccessoryButton: ButtonConfig? = nil,
                     appearAction: (() -> Void)? = nil,
@@ -78,6 +82,7 @@ open class FancyAlertViewController: UIViewController {
             self.dividerPosition = dividerPosition
             self.defaultButton = defaultButton
             self.cancelButton = cancelButton
+            self.neverButton = neverButton
             self.moreInfoButton = moreInfoButton
             self.titleAccessoryButton = titleAccessoryButton
             self.appearAction = appearAction
@@ -218,6 +223,7 @@ open class FancyAlertViewController: UIViewController {
 
         update(alertView.defaultButton, with: configuration.defaultButton)
         update(alertView.cancelButton, with: configuration.cancelButton)
+        update(alertView.neverButton, with: configuration.neverButton)
         update(alertView.moreInfoButton, with: configuration.moreInfoButton)
         update(alertView.titleAccessoryButton, with: configuration.titleAccessoryButton)
 

--- a/WordPressUI/FancyAlert/FancyAlerts.storyboard
+++ b/WordPressUI/FancyAlert/FancyAlerts.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="ZA1-84-qnC">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="ZA1-84-qnC">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
         <capability name="Alignment constraints to the first baseline" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -71,17 +71,17 @@
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JVE-OD-Ia7">
-                                                        <rect key="frame" x="0.0" y="162" width="334" height="49"/>
+                                                        <rect key="frame" x="0.0" y="162" width="334" height="10.5"/>
                                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" priority="750" constant="1" id="lCv-jy-vNg"/>
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rzT-7k-QCD" userLabel="Content Container">
-                                                        <rect key="frame" x="0.0" y="211" width="334" height="87"/>
+                                                        <rect key="frame" x="0.0" y="172.5" width="334" height="125.5"/>
                                                         <subviews>
                                                             <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="999" verticalHuggingPriority="999" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rH2-Nt-ZNa">
-                                                                <rect key="frame" x="-20.5" y="16" width="0.0" height="30"/>
+                                                                <rect key="frame" x="71.5" y="16" width="46" height="30"/>
                                                                 <inset key="titleEdgeInsets" minX="0.0" minY="4" maxX="0.0" maxY="4"/>
                                                                 <state key="normal" title="Button"/>
                                                                 <connections>
@@ -89,28 +89,28 @@
                                                                 </connections>
                                                             </button>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="249" verticalHuggingPriority="251" horizontalCompressionResistancePriority="999" verticalCompressionResistancePriority="1000" text=" " textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="75Q-Jn-AFH" userLabel="Alignment Placeholder">
-                                                                <rect key="frame" x="-20.5" y="20" width="4.5" height="20.5"/>
+                                                                <rect key="frame" x="63.5" y="20" width="4.5" height="20.5"/>
                                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="30" baselineRelativeArrangement="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Er7-dR-3IB" userLabel="Content Stack View">
-                                                                <rect key="frame" x="20" y="20" width="294" height="47"/>
+                                                                <rect key="frame" x="20" y="20" width="294" height="85.5"/>
                                                                 <subviews>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="249" verticalHuggingPriority="251" horizontalCompressionResistancePriority="999" verticalCompressionResistancePriority="1000" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cUO-4N-FhV">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="0.0" height="20.5"/>
+                                                                        <rect key="frame" x="0.0" y="0.0" width="43.5" height="20.5"/>
                                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                                         <nil key="textColor"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="OPz-wQ-LdM">
-                                                                        <rect key="frame" x="0.0" y="31.5" width="0.0" height="0.0"/>
+                                                                        <rect key="frame" x="0.0" y="31.5" width="37.5" height="18"/>
                                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                                         <nil key="textColor"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bwf-Ap-GLo">
-                                                                        <rect key="frame" x="0.0" y="40" width="46" height="7"/>
+                                                                        <rect key="frame" x="0.0" y="55.5" width="46" height="30"/>
                                                                         <state key="normal" title="Button"/>
                                                                         <connections>
                                                                             <action selector="buttonTapped:" destination="ZA1-84-qnC" eventType="touchUpInside" id="3PW-eX-0Sw"/>
@@ -145,8 +145,19 @@
                                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="Ut8-yb-neA" userLabel="Button Stack View">
                                                                 <rect key="frame" x="20" y="20" width="294" height="46"/>
                                                                 <subviews>
+                                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wFm-sT-H6c" userLabel="Never Button" customClass="FancyButton" customModule="WordPressUI" customModuleProvider="target">
+                                                                        <rect key="frame" x="0.0" y="0.0" width="84.5" height="46"/>
+                                                                        <accessibility key="accessibilityConfiguration" identifier="cancelAlertButton"/>
+                                                                        <state key="normal" title="Not Now"/>
+                                                                        <userDefinedRuntimeAttributes>
+                                                                            <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="NO"/>
+                                                                        </userDefinedRuntimeAttributes>
+                                                                        <connections>
+                                                                            <action selector="buttonTapped:" destination="ZA1-84-qnC" eventType="touchUpInside" id="r98-Gp-Tb3"/>
+                                                                        </connections>
+                                                                    </button>
                                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qlO-59-AKI" customClass="FancyButton" customModule="WordPressUI" customModuleProvider="target">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="137" height="46"/>
+                                                                        <rect key="frame" x="104.5" y="0.0" width="85" height="46"/>
                                                                         <accessibility key="accessibilityConfiguration" identifier="cancelAlertButton"/>
                                                                         <state key="normal" title="Not Now"/>
                                                                         <userDefinedRuntimeAttributes>
@@ -157,7 +168,7 @@
                                                                         </connections>
                                                                     </button>
                                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Bju-kg-VqX" customClass="FancyButton" customModule="WordPressUI" customModuleProvider="target">
-                                                                        <rect key="frame" x="157" y="0.0" width="137" height="46"/>
+                                                                        <rect key="frame" x="209.5" y="0.0" width="84.5" height="46"/>
                                                                         <accessibility key="accessibilityConfiguration" identifier="defaultAlertButton"/>
                                                                         <state key="normal" title="Try It"/>
                                                                         <userDefinedRuntimeAttributes>
@@ -223,6 +234,7 @@
                             <outlet property="headerImageViewWrapperBottomConstraint" destination="H7l-cv-jTE" id="Ngi-WU-EAx"/>
                             <outlet property="headerImageWrapperView" destination="zUD-7D-1OQ" id="VWO-PN-oRv"/>
                             <outlet property="moreInfoButton" destination="bwf-Ap-GLo" id="icj-gN-96T"/>
+                            <outlet property="neverButton" destination="wFm-sT-H6c" id="xHo-g8-e9h"/>
                             <outlet property="titleAccessoryButton" destination="rH2-Nt-ZNa" id="PfB-No-P1Y"/>
                             <outlet property="titleAccessoryButtonTrailingConstraint" destination="A7y-8k-dtG" id="pB9-68-Zb9"/>
                             <outlet property="titleLabel" destination="cUO-4N-FhV" id="4Rs-Xi-BfZ"/>


### PR DESCRIPTION
Adds a third button to the `FancyAlert`, which is required for Quick Start.

![simulator screen shot - iphone x - 2018-09-19 at 14 17 20](https://user-images.githubusercontent.com/517257/45782243-1f49cc80-bc17-11e8-8446-913432cab72a.png)

To test:
- in WPiOS, ensure that the existing alerts still work (prime for push after login or async alert after publishing first post)
- in WPiOS, on branch `issue/9447-add-never-to-QS-alert` ensure that there is a third button on the quick start alert, after creating a new `wpcom` site.