### PR TITLE
Adds optional bottom switch to FancyAlertView

### DIFF
--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		F1C4EBFA218A37D800B8A9F7 /* ExampleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C4EBF9218A37D800B8A9F7 /* ExampleTests.swift */; };
 		F1C4EC05218A37D800B8A9F7 /* ExampleUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C4EC04218A37D800B8A9F7 /* ExampleUITests.swift */; };
 		F1C4EC20218A386100B8A9F7 /* WordPressUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F1C4EC1A218A385100B8A9F7 /* WordPressUI.framework */; };
+		F1C61C80218B3E5300F30530 /* WordPressUI.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = F1C4EC1A218A385100B8A9F7 /* WordPressUI.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -54,6 +55,19 @@
 			remoteInfo = WordPressUI;
 		};
 /* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		F1C61C7E218B3E4600F30530 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				F1C61C80218B3E5300F30530 /* WordPressUI.framework in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		F1C4EBE1218A37D700B8A9F7 /* Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -185,6 +199,7 @@
 				F1C4EBDD218A37D700B8A9F7 /* Sources */,
 				F1C4EBDE218A37D700B8A9F7 /* Frameworks */,
 				F1C4EBDF218A37D700B8A9F7 /* Resources */,
+				F1C61C7E218B3E4600F30530 /* CopyFiles */,
 			);
 			buildRules = (
 			);

--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -20,7 +20,7 @@ class ViewController: UITableViewController
             DemoSection(title: "Fancy Alert", rows: [
                 DemoRow(title: "Fancy Alert", action: {
                     self.showFancyAlert() }),
-                DemoRow(title: "Fancy Alert (More Info)", action: {
+                DemoRow(title: "Fancy Alert (Full)", action: {
                     self.showFancyAlertWithMoreInfo() }),
                 ]
             ),

--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -6,6 +6,8 @@ import WordPressUI
 class ViewController: UITableViewController
 {
     
+    private typealias CompletionClosure = () -> ()
+    
     let cellIdentifier = "CellIdentifier"
     var sections: [DemoSection]!
     
@@ -18,6 +20,8 @@ class ViewController: UITableViewController
             DemoSection(title: "Fancy Alert", rows: [
                 DemoRow(title: "Fancy Alert", action: {
                     self.showFancyAlert() }),
+                DemoRow(title: "Fancy Alert (More Info)", action: {
+                    self.showFancyAlertWithMoreInfo() }),
                 ]
             ),
             DemoSection(title: "Misc UI Elements", rows: []),
@@ -37,9 +41,12 @@ class ViewController: UITableViewController
     
     // MARK: Fancy Alert
     
-    func showFancyAlert() {
+    func showFancyAlert(moreInfoButton: FancyAlertViewController.Config.ButtonConfig? = nil) {
         let defaultButton = FancyAlertViewController.Config.ButtonConfig(FancyAlertConstants.defaultButtonTitle) { (controller: FancyAlertViewController, button: UIButton) in
-            controller.dismiss(animated: true)
+            
+            self.show(message: FancyAlertConstants.defaultButtonTitle, from: controller) {
+                controller.dismiss(animated: true)
+            }
         }
         
         let cancelButton = FancyAlertViewController.Config.ButtonConfig(FancyAlertConstants.cancelButtonTitle) { (controller: FancyAlertViewController, button: UIButton) in
@@ -52,7 +59,8 @@ class ViewController: UITableViewController
             headerImage: nil,
             dividerPosition: nil,
             defaultButton: defaultButton,
-            cancelButton: cancelButton)
+            cancelButton: cancelButton,
+            moreInfoButton: moreInfoButton)
         
         let alert = FancyAlertViewController.controllerWithConfiguration(configuration: configuration)
         alert.modalPresentationStyle = .custom
@@ -61,7 +69,28 @@ class ViewController: UITableViewController
         present(alert, animated: true, completion: nil)
     }
     
-    // MARK: TableView Methods
+    func showFancyAlertWithMoreInfo() {
+        let moreInfoButton = FancyAlertViewController.Config.ButtonConfig(FancyAlertConstants.moreInfoButtonTitle) { [unowned self] (controller: FancyAlertViewController, button: UIButton) in
+            
+            self.show(message: FancyAlertConstants.moreInfoButtonTitle, from: controller)
+        }
+        
+        showFancyAlert(moreInfoButton: moreInfoButton)
+    }
+    
+    // MARK: - Test Messages for the User
+    
+    private func show(message: String, from controller: UIViewController, completion onCompletion: CompletionClosure? = nil) {
+        let alertViewController = UIAlertController(title: nil, message: message, preferredStyle: .alert)
+        
+        alertViewController.addActionWithTitle("Ok", style: .default) { alertAction in
+            onCompletion?()
+        }
+        
+        controller.present(alertViewController, animated: true, completion: nil)
+    }
+    
+    // MARK: - TableView Methods
     
     override func numberOfSections(in tableView: UITableView) -> Int {
         return sections.count

--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -19,10 +19,14 @@ class ViewController: UITableViewController
         sections = [
             DemoSection(title: "Fancy Alert", rows: [
                 DemoRow(title: "Fancy Alert", action: {
-                    self.showFancyAlert() }),
+                    self.showFancyAlert()
+                }),
                 DemoRow(title: "Fancy Alert (Full)", action: {
-                    self.showFancyAlertWithMoreInfo() }),
-                ]
+                    self.showFancyAlertWithMoreInfo()
+                }),
+                DemoRow(title: "Fancy Alert (Switch)", action: {
+                    self.showFancyAlertWithSwitch()
+                })]
             ),
             DemoSection(title: "Misc UI Elements", rows: []),
         ]
@@ -37,11 +41,16 @@ class ViewController: UITableViewController
         static let defaultButtonTitle =  "Go Ahead"
         static let cancelButtonTitle = "Cancel"
         static let moreInfoButtonTitle = "More Information"
+        
+        static let switchText = "Do not show this again"
     }
     
     // MARK: Fancy Alert
     
-    func showFancyAlert(moreInfoButton: FancyAlertViewController.Config.ButtonConfig? = nil) {
+    func showFancyAlert(
+        moreInfoButton: FancyAlertViewController.Config.ButtonConfig? = nil,
+        switchConfig: FancyAlertViewController.Config.SwitchConfig? = nil) {
+        
         let defaultButton = FancyAlertViewController.Config.ButtonConfig(FancyAlertConstants.defaultButtonTitle) { (controller: FancyAlertViewController, button: UIButton) in
             
             self.show(message: FancyAlertConstants.defaultButtonTitle, from: controller) {
@@ -60,7 +69,8 @@ class ViewController: UITableViewController
             dividerPosition: nil,
             defaultButton: defaultButton,
             cancelButton: cancelButton,
-            moreInfoButton: moreInfoButton)
+            moreInfoButton: moreInfoButton,
+            switchConfig: switchConfig)
         
         let alert = FancyAlertViewController.controllerWithConfiguration(configuration: configuration)
         alert.modalPresentationStyle = .custom
@@ -76,6 +86,22 @@ class ViewController: UITableViewController
         }
         
         showFancyAlert(moreInfoButton: moreInfoButton)
+    }
+    
+    func showFancyAlertWithSwitch() {
+        
+        let switchConfig = FancyAlertViewController.Config.SwitchConfig(
+            initialValue: true,
+            text: FancyAlertConstants.switchText,
+            action: { (controller, theSwitch) in
+                if theSwitch.isOn {
+                    self.show(message: "ON", from: controller)
+                } else {
+                    self.show(message: "OFF", from: controller)
+                }
+        })
+        
+        showFancyAlert(switchConfig: switchConfig)
     }
     
     // MARK: - Test Messages for the User

--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -47,9 +47,8 @@ class ViewController: UITableViewController
     
     // MARK: Fancy Alert
     
-    func showFancyAlert(
-        moreInfoButton: FancyAlertViewController.Config.ButtonConfig? = nil,
-        switchConfig: FancyAlertViewController.Config.SwitchConfig? = nil) {
+    func showFancyAlert(moreInfoButton: FancyAlertViewController.Config.ButtonConfig? = nil,
+                        switchConfig: FancyAlertViewController.Config.SwitchConfig? = nil) {
         
         let defaultButton = FancyAlertViewController.Config.ButtonConfig(FancyAlertConstants.defaultButtonTitle) { (controller: FancyAlertViewController, button: UIButton) in
             
@@ -89,7 +88,6 @@ class ViewController: UITableViewController
     }
     
     func showFancyAlertWithSwitch() {
-        
         let switchConfig = FancyAlertViewController.Config.SwitchConfig(
             initialValue: true,
             text: FancyAlertConstants.switchText,

--- a/WordPressUI/FancyAlert/FancyAlertView.swift
+++ b/WordPressUI/FancyAlert/FancyAlertView.swift
@@ -41,6 +41,12 @@ open class FancyAlertView: UIView {
     @IBOutlet weak var buttonStackView: UIStackView!
     @IBOutlet weak var buttonWrapperView: UIView!
     @IBOutlet weak var buttonWrapperViewTopConstraint: NSLayoutConstraint?
+    
+    /// Switch
+    ///
+    @IBOutlet weak var bottomSwitch: UISwitch!
+    @IBOutlet weak var bottomSwitchLabel: UILabel!
+    @IBOutlet weak var bottomSwitchWrapper: UIView!
 
     /// Wraps the entire view to give it a background and rounded corners
     ///

--- a/WordPressUI/FancyAlert/FancyAlerts.storyboard
+++ b/WordPressUI/FancyAlert/FancyAlerts.storyboard
@@ -70,14 +70,14 @@
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JVE-OD-Ia7">
-                                                        <rect key="frame" x="0.0" y="162" width="334" height="26.5"/>
+                                                        <rect key="frame" x="0.0" y="169" width="334" height="1"/>
                                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" priority="750" constant="1" id="lCv-jy-vNg"/>
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rzT-7k-QCD" userLabel="Content Container">
-                                                        <rect key="frame" x="0.0" y="188.5" width="334" height="125.5"/>
+                                                        <rect key="frame" x="0.0" y="177" width="334" height="125.5"/>
                                                         <subviews>
                                                             <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="999" verticalHuggingPriority="999" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rH2-Nt-ZNa">
                                                                 <rect key="frame" x="71.5" y="15.5" width="46" height="30"/>
@@ -132,14 +132,14 @@
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="SLm-WS-1GK">
-                                                        <rect key="frame" x="0.0" y="314" width="334" height="1"/>
+                                                        <rect key="frame" x="0.0" y="310" width="334" height="1"/>
                                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" priority="750" constant="1" id="T3v-yU-SxK"/>
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fve-0t-icO">
-                                                        <rect key="frame" x="0.0" y="315" width="334" height="74"/>
+                                                        <rect key="frame" x="0.0" y="318" width="334" height="74"/>
                                                         <subviews>
                                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="Ut8-yb-neA" userLabel="Button Stack View">
                                                                 <rect key="frame" x="20" y="20" width="294" height="34"/>
@@ -189,10 +189,10 @@
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ph1-QO-mym" userLabel="BottomSwitchWrapper">
-                                                        <rect key="frame" x="0.0" y="389" width="334" height="61"/>
+                                                        <rect key="frame" x="0.0" y="399" width="334" height="51"/>
                                                         <subviews>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Zxx-xY-nfG">
-                                                                <rect key="frame" x="20" y="10" width="294" height="31"/>
+                                                                <rect key="frame" x="20" y="0.0" width="294" height="31"/>
                                                                 <subviews>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Do not show this again." lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Vow-oZ-nG9">
                                                                         <rect key="frame" x="0.0" y="0.0" width="237" height="31"/>
@@ -222,7 +222,7 @@
                                                         </subviews>
                                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <constraints>
-                                                            <constraint firstItem="Zxx-xY-nfG" firstAttribute="top" secondItem="Ph1-QO-mym" secondAttribute="top" constant="10" id="CEf-p6-iOb"/>
+                                                            <constraint firstItem="Zxx-xY-nfG" firstAttribute="top" secondItem="Ph1-QO-mym" secondAttribute="top" id="CEf-p6-iOb"/>
                                                             <constraint firstAttribute="trailing" secondItem="Zxx-xY-nfG" secondAttribute="trailing" constant="20" id="Mcy-nX-SJV"/>
                                                             <constraint firstAttribute="bottom" secondItem="Zxx-xY-nfG" secondAttribute="bottom" constant="20" id="Oqd-Ol-Fze"/>
                                                             <constraint firstItem="Zxx-xY-nfG" firstAttribute="leading" secondItem="Ph1-QO-mym" secondAttribute="leading" constant="20" id="g3G-gw-Sbh"/>

--- a/WordPressUI/FancyAlert/FancyAlerts.storyboard
+++ b/WordPressUI/FancyAlert/FancyAlerts.storyboard
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="ZA1-84-qnC">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="ZA1-84-qnC">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
-        <capability name="Alignment constraints to the first baseline" minToolsVersion="6.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.14"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -23,10 +22,10 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="p02-zc-mb5">
-                                <rect key="frame" x="0.0" y="141" width="375" height="385"/>
+                                <rect key="frame" x="0.0" y="108.5" width="375" height="450"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="HFL-PH-DaB" userLabel="Padding">
-                                        <rect key="frame" x="0.0" y="0.0" width="20.5" height="385"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="20.5" height="450"/>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                         <constraints>
                                             <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="20" id="5oK-qi-G6x"/>
@@ -34,10 +33,10 @@
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Zfy-Hg-zeP">
-                                        <rect key="frame" x="20.5" y="0.0" width="334" height="385"/>
+                                        <rect key="frame" x="20.5" y="0.0" width="334" height="450"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="hxn-lJ-Q8T">
-                                                <rect key="frame" x="0.0" y="0.0" width="334" height="385"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="334" height="450"/>
                                                 <subviews>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zUD-7D-1OQ">
                                                         <rect key="frame" x="0.0" y="0.0" width="334" height="162"/>
@@ -71,17 +70,17 @@
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JVE-OD-Ia7">
-                                                        <rect key="frame" x="0.0" y="162" width="334" height="10.5"/>
+                                                        <rect key="frame" x="0.0" y="165" width="334" height="1"/>
                                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" priority="750" constant="1" id="lCv-jy-vNg"/>
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rzT-7k-QCD" userLabel="Content Container">
-                                                        <rect key="frame" x="0.0" y="172.5" width="334" height="125.5"/>
+                                                        <rect key="frame" x="0.0" y="169" width="334" height="125.5"/>
                                                         <subviews>
                                                             <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="999" verticalHuggingPriority="999" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rH2-Nt-ZNa">
-                                                                <rect key="frame" x="71.5" y="16" width="46" height="30"/>
+                                                                <rect key="frame" x="71.5" y="15.5" width="46" height="30"/>
                                                                 <inset key="titleEdgeInsets" minX="0.0" minY="4" maxX="0.0" maxY="4"/>
                                                                 <state key="normal" title="Button"/>
                                                                 <connections>
@@ -140,13 +139,13 @@
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fve-0t-icO">
-                                                        <rect key="frame" x="0.0" y="299" width="334" height="86"/>
+                                                        <rect key="frame" x="0.0" y="302" width="334" height="74"/>
                                                         <subviews>
                                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="Ut8-yb-neA" userLabel="Button Stack View">
-                                                                <rect key="frame" x="20" y="20" width="294" height="46"/>
+                                                                <rect key="frame" x="20" y="20" width="294" height="34"/>
                                                                 <subviews>
                                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wFm-sT-H6c" userLabel="Never Button" customClass="FancyButton" customModule="WordPressUI" customModuleProvider="target">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="84.5" height="46"/>
+                                                                        <rect key="frame" x="0.0" y="0.0" width="84.5" height="34"/>
                                                                         <accessibility key="accessibilityConfiguration" identifier="cancelAlertButton"/>
                                                                         <state key="normal" title="Not Now"/>
                                                                         <userDefinedRuntimeAttributes>
@@ -157,7 +156,7 @@
                                                                         </connections>
                                                                     </button>
                                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qlO-59-AKI" customClass="FancyButton" customModule="WordPressUI" customModuleProvider="target">
-                                                                        <rect key="frame" x="104.5" y="0.0" width="85" height="46"/>
+                                                                        <rect key="frame" x="104.5" y="0.0" width="85" height="34"/>
                                                                         <accessibility key="accessibilityConfiguration" identifier="cancelAlertButton"/>
                                                                         <state key="normal" title="Not Now"/>
                                                                         <userDefinedRuntimeAttributes>
@@ -168,7 +167,7 @@
                                                                         </connections>
                                                                     </button>
                                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Bju-kg-VqX" customClass="FancyButton" customModule="WordPressUI" customModuleProvider="target">
-                                                                        <rect key="frame" x="209.5" y="0.0" width="84.5" height="46"/>
+                                                                        <rect key="frame" x="209.5" y="0.0" width="84.5" height="34"/>
                                                                         <accessibility key="accessibilityConfiguration" identifier="defaultAlertButton"/>
                                                                         <state key="normal" title="Try It"/>
                                                                         <userDefinedRuntimeAttributes>
@@ -189,9 +188,49 @@
                                                             <constraint firstAttribute="bottom" secondItem="Ut8-yb-neA" secondAttribute="bottom" priority="999" constant="20" id="vQR-bH-LzU"/>
                                                         </constraints>
                                                     </view>
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ph1-QO-mym" userLabel="BottomSwitchWrapper">
+                                                        <rect key="frame" x="0.0" y="379" width="334" height="71"/>
+                                                        <subviews>
+                                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Zxx-xY-nfG">
+                                                                <rect key="frame" x="20" y="20" width="294" height="31"/>
+                                                                <subviews>
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Do not show this again." textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Vow-oZ-nG9">
+                                                                        <rect key="frame" x="0.0" y="0.0" width="237" height="31"/>
+                                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                                                                        <nil key="textColor"/>
+                                                                        <nil key="highlightedColor"/>
+                                                                    </label>
+                                                                    <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="iHe-6E-4yN">
+                                                                        <rect key="frame" x="245" y="0.0" width="51" height="31"/>
+                                                                        <constraints>
+                                                                            <constraint firstAttribute="width" constant="49" id="Wkr-xK-jzp"/>
+                                                                            <constraint firstAttribute="height" constant="31" id="qeZ-7j-NvC"/>
+                                                                        </constraints>
+                                                                    </switch>
+                                                                </subviews>
+                                                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="trailing" secondItem="iHe-6E-4yN" secondAttribute="trailing" id="4cm-0K-1HO"/>
+                                                                    <constraint firstItem="Vow-oZ-nG9" firstAttribute="top" secondItem="Zxx-xY-nfG" secondAttribute="top" id="6Ql-e3-IMc"/>
+                                                                    <constraint firstAttribute="bottom" secondItem="Vow-oZ-nG9" secondAttribute="bottom" id="AnJ-Yz-nIa"/>
+                                                                    <constraint firstAttribute="bottom" secondItem="iHe-6E-4yN" secondAttribute="bottom" id="Uqt-2B-xDJ"/>
+                                                                    <constraint firstItem="Vow-oZ-nG9" firstAttribute="leading" secondItem="Zxx-xY-nfG" secondAttribute="leading" id="ZDO-OC-mNY"/>
+                                                                    <constraint firstItem="iHe-6E-4yN" firstAttribute="top" secondItem="Zxx-xY-nfG" secondAttribute="top" id="aV2-EF-xwD"/>
+                                                                    <constraint firstItem="iHe-6E-4yN" firstAttribute="leading" secondItem="Vow-oZ-nG9" secondAttribute="trailing" constant="8" id="cLf-7f-t6N"/>
+                                                                </constraints>
+                                                            </view>
+                                                        </subviews>
+                                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        <constraints>
+                                                            <constraint firstItem="Zxx-xY-nfG" firstAttribute="top" secondItem="Ph1-QO-mym" secondAttribute="top" constant="20" id="CEf-p6-iOb"/>
+                                                            <constraint firstAttribute="trailing" secondItem="Zxx-xY-nfG" secondAttribute="trailing" constant="20" id="Mcy-nX-SJV"/>
+                                                            <constraint firstAttribute="bottom" secondItem="Zxx-xY-nfG" secondAttribute="bottom" constant="20" id="Oqd-Ol-Fze"/>
+                                                            <constraint firstItem="Zxx-xY-nfG" firstAttribute="leading" secondItem="Ph1-QO-mym" secondAttribute="leading" constant="20" id="g3G-gw-Sbh"/>
+                                                        </constraints>
+                                                    </view>
                                                 </subviews>
                                                 <constraints>
-                                                    <constraint firstAttribute="height" relation="lessThanOrEqual" constant="385" placeholder="YES" id="BHS-fz-5cm"/>
+                                                    <constraint firstAttribute="height" relation="lessThanOrEqual" constant="450" placeholder="YES" id="BHS-fz-5cm"/>
                                                 </constraints>
                                             </stackView>
                                         </subviews>
@@ -205,7 +244,7 @@
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="GWg-BX-CHE" userLabel="Padding">
-                                        <rect key="frame" x="354.5" y="0.0" width="20.5" height="385"/>
+                                        <rect key="frame" x="354.5" y="0.0" width="20.5" height="450"/>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                     </view>
                                 </subviews>
@@ -223,6 +262,9 @@
                         <connections>
                             <outlet property="bodyLabel" destination="OPz-wQ-LdM" id="rri-jS-Dkc"/>
                             <outlet property="bottomDividerView" destination="SLm-WS-1GK" id="aag-9a-Hrd"/>
+                            <outlet property="bottomSwitch" destination="iHe-6E-4yN" id="962-d9-gjB"/>
+                            <outlet property="bottomSwitchLabel" destination="Vow-oZ-nG9" id="Hib-09-hIA"/>
+                            <outlet property="bottomSwitchWrapper" destination="Ph1-QO-mym" id="Nvk-FL-i39"/>
                             <outlet property="buttonStackView" destination="Ut8-yb-neA" id="CLq-fZ-TMD"/>
                             <outlet property="buttonWrapperView" destination="fve-0t-icO" id="8Yl-iO-nbf"/>
                             <outlet property="buttonWrapperViewTopConstraint" destination="dmr-Er-FDx" id="aSA-Gt-jnw"/>

--- a/WordPressUI/FancyAlert/FancyAlerts.storyboard
+++ b/WordPressUI/FancyAlert/FancyAlerts.storyboard
@@ -70,14 +70,14 @@
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JVE-OD-Ia7">
-                                                        <rect key="frame" x="0.0" y="165" width="334" height="1"/>
+                                                        <rect key="frame" x="0.0" y="162" width="334" height="26.5"/>
                                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" priority="750" constant="1" id="lCv-jy-vNg"/>
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rzT-7k-QCD" userLabel="Content Container">
-                                                        <rect key="frame" x="0.0" y="169" width="334" height="125.5"/>
+                                                        <rect key="frame" x="0.0" y="188.5" width="334" height="125.5"/>
                                                         <subviews>
                                                             <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="999" verticalHuggingPriority="999" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rH2-Nt-ZNa">
                                                                 <rect key="frame" x="71.5" y="15.5" width="46" height="30"/>
@@ -132,14 +132,14 @@
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="SLm-WS-1GK">
-                                                        <rect key="frame" x="0.0" y="298" width="334" height="1"/>
+                                                        <rect key="frame" x="0.0" y="314" width="334" height="1"/>
                                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" priority="750" constant="1" id="T3v-yU-SxK"/>
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fve-0t-icO">
-                                                        <rect key="frame" x="0.0" y="302" width="334" height="74"/>
+                                                        <rect key="frame" x="0.0" y="315" width="334" height="74"/>
                                                         <subviews>
                                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="Ut8-yb-neA" userLabel="Button Stack View">
                                                                 <rect key="frame" x="20" y="20" width="294" height="34"/>
@@ -189,12 +189,12 @@
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ph1-QO-mym" userLabel="BottomSwitchWrapper">
-                                                        <rect key="frame" x="0.0" y="379" width="334" height="71"/>
+                                                        <rect key="frame" x="0.0" y="389" width="334" height="61"/>
                                                         <subviews>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Zxx-xY-nfG">
-                                                                <rect key="frame" x="20" y="20" width="294" height="31"/>
+                                                                <rect key="frame" x="20" y="10" width="294" height="31"/>
                                                                 <subviews>
-                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Do not show this again." textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Vow-oZ-nG9">
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Do not show this again." lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Vow-oZ-nG9">
                                                                         <rect key="frame" x="0.0" y="0.0" width="237" height="31"/>
                                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                                                         <nil key="textColor"/>
@@ -222,7 +222,7 @@
                                                         </subviews>
                                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <constraints>
-                                                            <constraint firstItem="Zxx-xY-nfG" firstAttribute="top" secondItem="Ph1-QO-mym" secondAttribute="top" constant="20" id="CEf-p6-iOb"/>
+                                                            <constraint firstItem="Zxx-xY-nfG" firstAttribute="top" secondItem="Ph1-QO-mym" secondAttribute="top" constant="10" id="CEf-p6-iOb"/>
                                                             <constraint firstAttribute="trailing" secondItem="Zxx-xY-nfG" secondAttribute="trailing" constant="20" id="Mcy-nX-SJV"/>
                                                             <constraint firstAttribute="bottom" secondItem="Zxx-xY-nfG" secondAttribute="bottom" constant="20" id="Oqd-Ol-Fze"/>
                                                             <constraint firstItem="Zxx-xY-nfG" firstAttribute="leading" secondItem="Ph1-QO-mym" secondAttribute="leading" constant="20" id="g3G-gw-Sbh"/>


### PR DESCRIPTION
### Description:

This PR adds an optional bottom switch to `FancyAlertView`.  This is intended to be used (at least initially) as a "Do not show this again" option for the alert.

Also adds 2 demos to showcase the "More information" button and the newly added switch.

Also fixes all unit tests.

### Testing:

Make sure the code looks fine.
Make sure the unit tests run fine.
Run the example App and:
- Open all 3 Fancy alert demos, and make sure they look fine.
- Try interacting with things and make sure an alert comes up describing your action.