### PR TITLE
Swift 4.2 Migration

### DIFF
--- a/WordPressUI.xcodeproj/project.pbxproj
+++ b/WordPressUI.xcodeproj/project.pbxproj
@@ -426,10 +426,12 @@
 				TargetAttributes = {
 					B59DCB5B202B146D00BEBD8A = {
 						CreatedOnToolsVersion = 9.2;
+						LastSwiftMigration = 1010;
 						ProvisioningStyle = Automatic;
 					};
 					B59DCB64202B146D00BEBD8A = {
 						CreatedOnToolsVersion = 9.2;
+						LastSwiftMigration = 1010;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -619,7 +621,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.WordPressUI;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = "Release-Alpha";
@@ -634,7 +636,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.WordPressUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = "Release-Alpha";
@@ -712,7 +714,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.WordPressUI;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = "Release-Internal";
@@ -727,7 +729,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.WordPressUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = "Release-Internal";
@@ -867,7 +869,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.WordPressUI;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -890,7 +892,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.WordPressUI;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -905,7 +907,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.WordPressUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -920,7 +922,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.WordPressUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/WordPressUI/Extensions/BlockEvents/UIBarButtonItem+BlockEvents.swift
+++ b/WordPressUI/Extensions/BlockEvents/UIBarButtonItem+BlockEvents.swift
@@ -3,7 +3,7 @@
 private final class BarButtonItemEventHandler<Sender: UIBarButtonItem>: NSObject {
     let closure: (Sender) -> Void
 
-    init(sender: Sender, events: UIControlEvents, closure: @escaping (Sender) -> Void) {
+    init(sender: Sender, events: UIControl.Event, closure: @escaping (Sender) -> Void) {
         self.closure = closure
         super.init()
 

--- a/WordPressUI/Extensions/BlockEvents/UIControl+BlockEvents.swift
+++ b/WordPressUI/Extensions/BlockEvents/UIControl+BlockEvents.swift
@@ -39,7 +39,7 @@ public extension ControlEventBindable where Self: UIControl {
     }
 
     /// Listen for `UIControlEvents` executing the provided closure when triggered
-    public func on(_ events: UIControlEvents, call closure: @escaping (Self) -> Void) {
+    public func on(_ events: UIControl.Event, call closure: @escaping (Self) -> Void) {
         let handler = ControlEventHandler<Self>(sender: self, events: events, closure: closure)
         self.controlEventHandlers.append(handler)
     }
@@ -50,7 +50,7 @@ public extension ControlEventBindable where Self: UIControl {
 private final class ControlEventHandler<Sender: UIControl>: NSObject {
     let closure: (Sender) -> Void
 
-    init(sender: Sender, events: UIControlEvents, closure: @escaping (Sender) -> Void) {
+    init(sender: Sender, events: UIControl.Event, closure: @escaping (Sender) -> Void) {
         self.closure = closure
         super.init()
 

--- a/WordPressUI/Extensions/UIAlertController+Helpers.swift
+++ b/WordPressUI/Extensions/UIAlertController+Helpers.swift
@@ -14,7 +14,7 @@ extension UIAlertController {
         return addActionWithTitle(title, style: .default, handler: handler)
     }
 
-    @objc @discardableResult public func addActionWithTitle(_ title: String?, style: UIAlertActionStyle, handler: ((UIAlertAction) -> Void)? = nil) -> UIAlertAction {
+    @objc @discardableResult public func addActionWithTitle(_ title: String?, style: UIAlertAction.Style, handler: ((UIAlertAction) -> Void)? = nil) -> UIAlertAction {
         let action = UIAlertAction(title: title, style: style, handler: handler)
         addAction(action)
 

--- a/WordPressUI/Extensions/UITableView+Helpers.swift
+++ b/WordPressUI/Extensions/UITableView+Helpers.swift
@@ -49,7 +49,7 @@ extension UITableView {
     ///     - scrollPosition:   The position in the table view to scroll the specified row. Use `.None` for no scrolling. Defaults to `.Middle`.
     ///     - completion:       A block to call after the row has been deselected.
     ///
-    @objc public func flashRowAtIndexPath(_ indexPath: IndexPath, scrollPosition: UITableViewScrollPosition = .middle, completion: (() -> Void)?) {
+    @objc public func flashRowAtIndexPath(_ indexPath: IndexPath, scrollPosition: UITableView.ScrollPosition = .middle, completion: (() -> Void)?) {
         flashRowAtIndexPath(indexPath, scrollPosition: scrollPosition, flashLength: type(of: self).defaultFlashLength, completion: completion)
     }
 
@@ -61,7 +61,7 @@ extension UITableView {
     ///     - flashLength:      The length of time (in seconds) to wait between selecting and deselecting the row.
     ///     - completion:       A block to call after the row has been deselected.
     ///
-    @objc public func flashRowAtIndexPath(_ indexPath: IndexPath, scrollPosition: UITableViewScrollPosition = .middle, flashLength: TimeInterval, completion: (() -> Void)?) {
+    @objc public func flashRowAtIndexPath(_ indexPath: IndexPath, scrollPosition: UITableView.ScrollPosition = .middle, flashLength: TimeInterval, completion: (() -> Void)?) {
         selectRow(at: indexPath, animated: true, scrollPosition: scrollPosition)
 
         let time = DispatchTime.now() + Double(Int64(flashLength * Double(NSEC_PER_SEC))) / Double(NSEC_PER_SEC)

--- a/WordPressUI/Extensions/UIView+Animations.swift
+++ b/WordPressUI/Extensions/UIView+Animations.swift
@@ -36,7 +36,7 @@ extension UIView {
                                    delay: delay,
                                    usingSpringWithDamping: damping,
                                    initialSpringVelocity: velocity,
-                                   options: UIViewAnimationOptions(),
+                                   options: UIView.AnimationOptions(),
                                    animations: animations,
                                    completion: completion)
     }
@@ -62,7 +62,7 @@ extension UIView {
             delay: delay,
             usingSpringWithDamping: damping,
             initialSpringVelocity: velocity,
-            options: UIViewAnimationOptions(),
+            options: UIView.AnimationOptions(),
             animations: animations,
             completion: completion
         )

--- a/WordPressUI/Extensions/UIViewController+Helpers.swift
+++ b/WordPressUI/Extensions/UIViewController+Helpers.swift
@@ -32,7 +32,7 @@ extension UIViewController {
         } else if let navigationController = self.navigationController {
             if navigationController.presentingViewController != nil &&
                 navigationController.presentingViewController?.presentedViewController == navigationController &&
-                navigationController.childViewControllers.first == self {
+                navigationController.children.first == self {
                 return true
             }
         }

--- a/WordPressUI/FancyAlert/FancyAlertViewController.swift
+++ b/WordPressUI/FancyAlert/FancyAlertViewController.swift
@@ -287,7 +287,7 @@ open class FancyAlertViewController: UIViewController {
 
         alertView.titleLabel.accessibilityHint = (isButtonless) ? NSLocalizedString("Double tap to dismiss", comment: "Voiceover accessibility hint informing the user they can double tap a modal alert to dismiss it") : nil
 
-        UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, alertView.titleLabel)
+        UIAccessibility.post(notification: UIAccessibility.Notification.screenChanged, argument: alertView.titleLabel)
     }
 
     private func updateHeaderImage() {

--- a/WordPressUI/Ghosts/Internal/GhostAnimation.swift
+++ b/WordPressUI/Ghosts/Internal/GhostAnimation.swift
@@ -34,7 +34,7 @@ class GhostAnimation: CABasicAnimation {
         super.init()
 
         keyPath = #keyPath(CALayer.backgroundColor)
-        timingFunction = CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseInEaseOut)
+        timingFunction = CAMediaTimingFunction(name: CAMediaTimingFunctionName.easeInEaseOut)
         repeatCount = .infinity
         autoreverses = true
     }

--- a/WordPressUI/Ghosts/Internal/GhostTableViewHandler.swift
+++ b/WordPressUI/Ghosts/Internal/GhostTableViewHandler.swift
@@ -53,6 +53,6 @@ extension GhostTableViewHandler: UITableViewDataSource {
 extension GhostTableViewHandler: UITableViewDelegate {
 
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return UITableViewAutomaticDimension
+        return UITableView.automaticDimension
     }
 }


### PR DESCRIPTION
### Details:
In this (super brief) PR we're migrating over swift 4.2, so that we can finally get rid of "That Xcode Warning".

@diegoreymendez may i bug you with a real quick one?
Thanks in advance!!

### Testing:
- [ ] Verify the Unit Tests pass
- [ ] Verify the framework builds correctly
