### PR TITLE
Improve image view extensions

### DIFF
--- a/WordPressUI.podspec
+++ b/WordPressUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressUI"
-  s.version       = "1.2.0"
+  s.version       = "1.2.1"
   s.summary       = "Home of reusable WordPress UI components."
 
   s.description   = <<-DESC

--- a/WordPressUI/Extensions/UIImageView+Networking.swift
+++ b/WordPressUI/Extensions/UIImageView+Networking.swift
@@ -40,6 +40,29 @@ public extension UIImageView {
             downloadTask?.cancel()
             return
         }
+        let request = self.request(for: url)
+        downloadImage(usingRequest: request, placeholderImage: placeholderImage, success: success, failure: failure)
+    }
+
+    /// Downloads an image and updates the current UIImageView Instance.
+    ///
+    /// - Parameters:
+    ///     -   request: The request of the target image
+    ///     -   placeholderImage: Image to be displayed while the actual asset gets downloaded.
+    ///     -   success: Closure to be executed on success.
+    ///     -   failure: Closure to be executed upon failure.
+    ///
+    @objc func downloadImage(usingRequest request: URLRequest, placeholderImage: UIImage? = nil, success: ((UIImage) -> ())? = nil, failure: ((Error?) -> ())? = nil) {
+        // Ideally speaking, this method should *not* receive an Optional URL. But we're doing so, for convenience.
+        // If the actual URL was nil, at least we set the Placeholder Image. Capicci?
+        guard let url = request.url else {
+            if let placeholderImage = placeholderImage {
+                image = placeholderImage
+            }
+            downloadURL = nil
+            downloadTask?.cancel()
+            return
+        }
 
         let internalOnSuccess = { [weak self] (image: UIImage) in
             self?.image = image
@@ -68,8 +91,6 @@ public extension UIImageView {
         if let placeholderImage = placeholderImage {
             image = placeholderImage
         }
-
-        let request = self.request(for: url)
 
         let task = URLSession.shared.dataTask(with: request, completionHandler: { [weak self] data, response, error in
             guard let data = data, let image = UIImage(data: data, scale: UIScreen.main.scale) else {

--- a/WordPressUI/Extensions/UIImageView+Networking.swift
+++ b/WordPressUI/Extensions/UIImageView+Networking.swift
@@ -10,7 +10,7 @@ public extension UIImageView {
     ///     -   placeholderImage: Image to be displayed while the actual asset gets downloaded.
     ///     -   pointSize: *Maximum* allowed size. if the actual asset exceeds this size, we'll shrink it down.
     ///
-    public func downloadResizedImage(from url: URL?, placeholderImage: UIImage? = nil, pointSize: CGSize) {
+    @objc func downloadResizedImage(from url: URL?, placeholderImage: UIImage? = nil, pointSize: CGSize) {
         downloadImage(from: url, placeholderImage: placeholderImage, success: { [weak self] image in
             guard image.size.height > pointSize.height || image.size.width > pointSize.width else {
                 self?.image = image
@@ -29,7 +29,7 @@ public extension UIImageView {
     ///     -   success: Closure to be executed on success.
     ///     -   failure: Closure to be executed upon failure.
     ///
-    public func downloadImage(from url: URL?, placeholderImage: UIImage? = nil, success: ((UIImage) -> ())? = nil, failure: ((Error?) -> ())? = nil) {
+    @objc func downloadImage(from url: URL?, placeholderImage: UIImage? = nil, success: ((UIImage) -> ())? = nil, failure: ((Error?) -> ())? = nil) {
         // Ideally speaking, this method should *not* receive an Optional URL. But we're doing so, for convenience.
         // If the actual URL was nil, at least we set the Placeholder Image. Capicci?
         guard let url = url else {
@@ -97,7 +97,7 @@ public extension UIImageView {
     /// Overrides the cached UIImage, for a given URL. This is useful for whenever we've just updated a remote resource,
     /// and we need to prevent returning the (old) cached entry.
     ///
-    public func overrideImageCache(for url: URL, with image: UIImage) {
+    @objc func overrideImageCache(for url: URL, with image: UIImage) {
         Downloader.cache.setObject(image, forKey: url as AnyObject)
 
         // Remove all cached responses - removing an individual response does not work since iOS 7.
@@ -106,6 +106,11 @@ public extension UIImageView {
         // Update: Years have gone by (iOS 11 era). Still broken. Still ashamed about this. Thank you, Apple.
         //
         URLSession.shared.configuration.urlCache?.removeAllCachedResponses()
+    }
+
+    @objc func cancelImageDownload() {        
+        downloadURL = nil
+        downloadTask?.cancel()
     }
 
 

--- a/WordPressUI/Extensions/UIImageView+Networking.swift
+++ b/WordPressUI/Extensions/UIImageView+Networking.swift
@@ -36,8 +36,7 @@ public extension UIImageView {
             if let placeholderImage = placeholderImage {
                 image = placeholderImage
             }
-            downloadURL = nil
-            downloadTask?.cancel()
+            cancelImageDownload()
             return
         }
         let request = self.request(for: url)
@@ -79,8 +78,8 @@ public extension UIImageView {
         }
 
         // Do this first, if there was any ongoing task for this imageview we need to cancel imediately or else we can apply the cache image and not cancel a previous download
+        cancelImageDownload()
         downloadURL = url
-        downloadTask?.cancel()
 
         if let image = cachedImage {
             internalOnSuccess(image)
@@ -108,7 +107,6 @@ public extension UIImageView {
             }
         })
 
-        downloadTask?.cancel()
         downloadTask = task
         task.resume()
     }

--- a/WordPressUI/Extensions/UIImageView+Networking.swift
+++ b/WordPressUI/Extensions/UIImageView+Networking.swift
@@ -108,7 +108,7 @@ public extension UIImageView {
         URLSession.shared.configuration.urlCache?.removeAllCachedResponses()
     }
 
-    @objc func cancelImageDownload() {        
+    @objc func cancelImageDownload() {
         downloadURL = nil
         downloadTask?.cancel()
     }

--- a/WordPressUI/Extensions/UIImageView+Networking.swift
+++ b/WordPressUI/Extensions/UIImageView+Networking.swift
@@ -47,7 +47,7 @@ public extension UIImageView {
     /// Downloads an image and updates the current UIImageView Instance.
     ///
     /// - Parameters:
-    ///     -   request: The request of the target image
+    ///     -   request: The request for the target image
     ///     -   placeholderImage: Image to be displayed while the actual asset gets downloaded.
     ///     -   success: Closure to be executed on success.
     ///     -   failure: Closure to be executed upon failure.
@@ -59,8 +59,7 @@ public extension UIImageView {
             if let placeholderImage = placeholderImage {
                 image = placeholderImage
             }
-            downloadURL = nil
-            downloadTask?.cancel()
+            cancelImageDownload()
             return
         }
 
@@ -129,6 +128,8 @@ public extension UIImageView {
         URLSession.shared.configuration.urlCache?.removeAllCachedResponses()
     }
 
+    /// Cancels the current download task and clear the downloadURL
+    ///
     @objc func cancelImageDownload() {
         downloadURL = nil
         downloadTask?.cancel()


### PR DESCRIPTION
This PR improves the interface of the UIImageView+Networking extension by adding the following methods:
 - cancelImageDownload
 - downloadImageUsingRequest

It also makes the public methods available trough ObjC in order from them to be used on ObjC code on the main app.

This will allow the complete replacement of the AFNetworking uses on the main app, by using this extension.