### PR TITLE
Adds changeLayoutMargins UIView helper

### DIFF
--- a/WordPressUI.xcodeproj/project.pbxproj
+++ b/WordPressUI.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		43067E2E203C8D03001DD610 /* UIBarButtonItem+BlockEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43067E2D203C8D03001DD610 /* UIBarButtonItem+BlockEvents.swift */; };
 		43067E30203C8D27001DD610 /* UIGestureRecognizer+BlockEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43067E2F203C8D27001DD610 /* UIGestureRecognizer+BlockEvents.swift */; };
 		57072D94228D897A007AA9C1 /* GhostableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57072D93228D897A007AA9C1 /* GhostableView.swift */; };
+		577FC78722985DD0005BA78F /* UIView+ChangeLayoutMarginsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 577FC78622985DD0005BA78F /* UIView+ChangeLayoutMarginsTests.swift */; };
 		57BC0C6D228DF1E000C1F070 /* UIView+GhostTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57BC0C6C228DF1E000C1F070 /* UIView+GhostTests.swift */; };
 		57BC0C6F228DF35400C1F070 /* UITableView+GhostTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57BC0C6E228DF35400C1F070 /* UITableView+GhostTests.swift */; };
 		828BEAC6203B59CD003F7078 /* UIImage+Crop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 828BEAC5203B59CD003F7078 /* UIImage+Crop.swift */; };
@@ -91,6 +92,7 @@
 		43067E2D203C8D03001DD610 /* UIBarButtonItem+BlockEvents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIBarButtonItem+BlockEvents.swift"; sourceTree = "<group>"; };
 		43067E2F203C8D27001DD610 /* UIGestureRecognizer+BlockEvents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIGestureRecognizer+BlockEvents.swift"; sourceTree = "<group>"; };
 		57072D93228D897A007AA9C1 /* GhostableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhostableView.swift; sourceTree = "<group>"; };
+		577FC78622985DD0005BA78F /* UIView+ChangeLayoutMarginsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+ChangeLayoutMarginsTests.swift"; sourceTree = "<group>"; };
 		57BC0C6C228DF1E000C1F070 /* UIView+GhostTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+GhostTests.swift"; sourceTree = "<group>"; };
 		57BC0C6E228DF35400C1F070 /* UITableView+GhostTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+GhostTests.swift"; sourceTree = "<group>"; };
 		828BEAC5203B59CD003F7078 /* UIImage+Crop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Crop.swift"; sourceTree = "<group>"; };
@@ -208,6 +210,7 @@
 				9A6EC88C21DA4832007815FF /* UIViewControllerHelperTest.swift */,
 				B5226C67207CCDB2003C606E /* GravatarTest.swift */,
 				B529F288202C855B00895D88 /* UIColorHelpersTests.swift */,
+				577FC78622985DD0005BA78F /* UIView+ChangeLayoutMarginsTests.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -561,6 +564,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				577FC78722985DD0005BA78F /* UIView+ChangeLayoutMarginsTests.swift in Sources */,
 				9A6EC88D21DA4832007815FF /* UIViewControllerHelperTest.swift in Sources */,
 				B529F289202C855B00895D88 /* UIColorHelpersTests.swift in Sources */,
 				57BC0C6D228DF1E000C1F070 /* UIView+GhostTests.swift in Sources */,

--- a/WordPressUI/Extensions/UIView+Helpers.swift
+++ b/WordPressUI/Extensions/UIView+Helpers.swift
@@ -51,4 +51,13 @@ extension UIView {
     @objc public func userInterfaceLayoutDirection() -> UIUserInterfaceLayoutDirection {
         return UIView.userInterfaceLayoutDirection(for: semanticContentAttribute)
     }
+
+    public func changeLayoutMargins(top: CGFloat? = nil, left: CGFloat? = nil, bottom: CGFloat? = nil, right: CGFloat? = nil) {
+        let top = top ?? layoutMargins.top
+        let left = left ?? layoutMargins.left
+        let bottom = bottom ?? layoutMargins.bottom
+        let right = right ?? layoutMargins.right
+
+        layoutMargins = UIEdgeInsets(top: top, left: left, bottom: bottom, right: right)
+    }
 }

--- a/WordPressUITests/Extensions/UIView+ChangeLayoutMarginsTests.swift
+++ b/WordPressUITests/Extensions/UIView+ChangeLayoutMarginsTests.swift
@@ -1,0 +1,50 @@
+import Foundation
+import XCTest
+
+@testable import WordPressUI
+
+class UIViewChangeLayoutMarginSTests: XCTestCase {
+
+    var view: UIView!
+
+    override func setUp() {
+        view = UIView()
+        view.layoutMargins = UIEdgeInsets(top: 5, left: 5, bottom: 5, right: 5)
+    }
+
+    func testChangeOnlyTopLayoutMargin() {
+        view.changeLayoutMargins(top: 10)
+
+        XCTAssertEqual(view.layoutMargins.top, 10)
+        XCTAssertEqual(view.layoutMargins.left, 5)
+        XCTAssertEqual(view.layoutMargins.bottom, 5)
+        XCTAssertEqual(view.layoutMargins.right, 5)
+    }
+
+    func testChangeOnlyLeftLayoutMargin() {
+        view.changeLayoutMargins(left: 10)
+
+        XCTAssertEqual(view.layoutMargins.top, 5)
+        XCTAssertEqual(view.layoutMargins.left, 10)
+        XCTAssertEqual(view.layoutMargins.bottom, 5)
+        XCTAssertEqual(view.layoutMargins.right, 5)
+    }
+
+    func testChangeOnlyBottomLayoutMargin() {
+        view.changeLayoutMargins(bottom: 10)
+
+        XCTAssertEqual(view.layoutMargins.top, 5)
+        XCTAssertEqual(view.layoutMargins.left, 5)
+        XCTAssertEqual(view.layoutMargins.bottom, 10)
+        XCTAssertEqual(view.layoutMargins.right, 5)
+    }
+
+    func testChangeOnlyRightLayoutMargin() {
+        view.changeLayoutMargins(right: 10)
+
+        XCTAssertEqual(view.layoutMargins.top, 5)
+        XCTAssertEqual(view.layoutMargins.left, 5)
+        XCTAssertEqual(view.layoutMargins.bottom, 5)
+        XCTAssertEqual(view.layoutMargins.right, 10)
+    }
+}


### PR DESCRIPTION
This PR aims to add a new `UIView` helper called `changeLayoutMargins`.

By using it, you can change any `UIView`'s `layoutMargins` without the need to inform a complete `UIEdgeInsect`.

Instead of:

```
view.layoutMargins = UIEdgeInsets(top: view.layoutMargins.top, left: 5, bottom: view.layoutMargins.bottom, right: view.layoutMargins.right)
```

Just:

```
view.changeLayoutMargins(left: 5)
```