### PR TITLE
isViewOnScreen: Detect presentedViewController

### DIFF
--- a/WordPressUI/Extensions/UIViewController+Helpers.swift
+++ b/WordPressUI/Extensions/UIViewController+Helpers.swift
@@ -9,9 +9,9 @@ extension UIViewController {
         let visibleAsTopOnStack = navigationController?.topViewController == self && view.window != nil
         let visibleAsPresented  = view.window?.rootViewController?.presentedViewController == self
 
-        let isPresentingAView = presentedViewController != nil
+        let isNotPresentingAView = presentedViewController == nil
 
-        return !isPresentingAView && (visibleAsRoot || visibleAsTopOnStack || visibleAsPresented)
+        return isNotPresentingAView && (visibleAsRoot || visibleAsTopOnStack || visibleAsPresented)
     }
 
     /// Determines if the current ViewController's View is horizontally Compact

--- a/WordPressUI/Extensions/UIViewController+Helpers.swift
+++ b/WordPressUI/Extensions/UIViewController+Helpers.swift
@@ -9,7 +9,9 @@ extension UIViewController {
         let visibleAsTopOnStack = navigationController?.topViewController == self && view.window != nil
         let visibleAsPresented  = view.window?.rootViewController?.presentedViewController == self
 
-        return visibleAsRoot || visibleAsTopOnStack || visibleAsPresented
+        let isPresentingAView = presentedViewController != nil
+
+        return !isPresentingAView && (visibleAsRoot || visibleAsTopOnStack || visibleAsPresented)
     }
 
     /// Determines if the current ViewController's View is horizontally Compact


### PR DESCRIPTION
This is part of https://github.com/wordpress-mobile/WordPress-iOS/pull/11811.

This fixes false positives when the subject ViewController is “presenting” another ViewController.