### PR TITLE
[Dark Mode] Fix the Fancy Alert View background colors

### DIFF
--- a/WordPressUI.podspec
+++ b/WordPressUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressUI"
-  s.version       = "1.3.5-beta.1"
+  s.version       = "1.3.5-beta.2"
   s.summary       = "Home of reusable WordPress UI components."
 
   s.description   = <<-DESC

--- a/WordPressUI/FancyAlert/FancyAlertView.swift
+++ b/WordPressUI/FancyAlert/FancyAlertView.swift
@@ -22,6 +22,7 @@ open class FancyAlertView: UIView {
     /// Body
     ///
     @IBOutlet weak var bodyLabel: UILabel!
+    @IBOutlet weak var bodyWrapperView: UIView!
 
     /// Dividers
     ///
@@ -79,6 +80,17 @@ open class FancyAlertView: UIView {
         }
         set {
             bodyLabel.textColor = newValue
+        }
+    }
+
+    /// BodyWrapper: backgroundColor
+    ///
+    @objc public dynamic var bodyBackgroundColor: UIColor? {
+        get {
+            return bodyWrapperView.backgroundColor
+        }
+        set {
+            bodyWrapperView.backgroundColor = newValue
         }
     }
 
@@ -169,6 +181,17 @@ open class FancyAlertView: UIView {
         }
         set {
             headerImageWrapperView.backgroundColor = newValue
+        }
+    }
+
+    /// ButtonWrapper: backgroundColor
+    ///
+    @objc public dynamic var bottomBackgroundColor: UIColor? {
+        get {
+            return buttonWrapperView.backgroundColor
+        }
+        set {
+            buttonWrapperView.backgroundColor = newValue
         }
     }
 

--- a/WordPressUI/FancyAlert/FancyAlerts.storyboard
+++ b/WordPressUI/FancyAlert/FancyAlerts.storyboard
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="ZA1-84-qnC">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14865.1" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="ZA1-84-qnC">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14819.2"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -231,6 +229,7 @@
                         </constraints>
                         <connections>
                             <outlet property="bodyLabel" destination="OPz-wQ-LdM" id="rri-jS-Dkc"/>
+                            <outlet property="bodyWrapperView" destination="rzT-7k-QCD" id="zeJ-jV-Dz8"/>
                             <outlet property="bottomDividerView" destination="SLm-WS-1GK" id="aag-9a-Hrd"/>
                             <outlet property="bottomSwitch" destination="iHe-6E-4yN" id="962-d9-gjB"/>
                             <outlet property="bottomSwitchLabel" destination="Vow-oZ-nG9" id="Hib-09-hIA"/>


### PR DESCRIPTION
This PR fixes the white background displayed in the Fancy Alerts on iOS 13 with Dark Mode enabled.

Refs. [#12320](https://github.com/wordpress-mobile/WordPress-iOS/issues/12320)

## To Test:
• Run [#12455](https://github.com/wordpress-mobile/WordPress-iOS/pull/12455)