### PR TITLE
Update fancy button border style

### DIFF
--- a/Example/Example/Base.lproj/Main.storyboard
+++ b/Example/Example/Base.lproj/Main.storyboard
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="PbN-Bb-478">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="PbN-Bb-478">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.14"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -18,7 +18,7 @@
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="CellIdentifier" id="3ZQ-84-wjW">
-                                <rect key="frame" x="0.0" y="28" width="375" height="44"/>
+                                <rect key="frame" x="0.0" y="28" width="375" height="43.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="3ZQ-84-wjW" id="38G-WI-5mN">
                                     <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
@@ -32,17 +32,103 @@
                         </connections>
                     </tableView>
                     <navigationItem key="navigationItem" title="Root View Controller" id="ua7-K6-ibe"/>
+                    <connections>
+                        <segue destination="sFZ-hP-s6g" kind="show" identifier="FancyButtonsSegue" id="avn-Um-QAq"/>
+                    </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="ePj-1F-MpD" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="566" y="-244"/>
+        </scene>
+        <!--Fancy Buttons View Controller-->
+        <scene sceneID="dk3-6b-6yt">
+            <objects>
+                <viewController id="sFZ-hP-s6g" customClass="FancyButtonsViewController" customModule="Example" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="ITQ-Ah-oIp">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="40" translatesAutoresizingMaskIntoConstraints="NO" id="4IX-T0-GRU">
+                                <rect key="frame" x="96.5" y="79.5" width="182" height="552"/>
+                                <subviews>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="DLq-Jr-68H" customClass="FancyButton" customModule="WordPressUI">
+                                        <rect key="frame" x="0.0" y="0.0" width="182" height="34"/>
+                                        <state key="normal" title="Primary enabled"/>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="YES"/>
+                                        </userDefinedRuntimeAttributes>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" selected="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="99W-Sf-T4r" customClass="FancyButton" customModule="WordPressUI">
+                                        <rect key="frame" x="0.0" y="74" width="182" height="34"/>
+                                        <state key="normal" title="Primary selected"/>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="YES"/>
+                                        </userDefinedRuntimeAttributes>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" highlighted="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="V1C-qw-HGz" customClass="FancyButton" customModule="WordPressUI">
+                                        <rect key="frame" x="0.0" y="148" width="182" height="34"/>
+                                        <state key="normal" title="Primary highlighted"/>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="YES"/>
+                                        </userDefinedRuntimeAttributes>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Rse-9O-SFu" customClass="FancyButton" customModule="WordPressUI">
+                                        <rect key="frame" x="0.0" y="222" width="182" height="34"/>
+                                        <state key="normal" title="Primary disabled"/>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="YES"/>
+                                        </userDefinedRuntimeAttributes>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="UAb-pT-sYQ" customClass="FancyButton" customModule="WordPressUI">
+                                        <rect key="frame" x="0.0" y="296" width="182" height="34"/>
+                                        <state key="normal" title="Secondary enabled"/>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="NO"/>
+                                        </userDefinedRuntimeAttributes>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" selected="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="raJ-LB-lIj" customClass="FancyButton" customModule="WordPressUI">
+                                        <rect key="frame" x="0.0" y="370" width="182" height="34"/>
+                                        <state key="normal" title="Secondary selected"/>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="NO"/>
+                                        </userDefinedRuntimeAttributes>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" highlighted="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5Cb-gy-BQF" customClass="FancyButton" customModule="WordPressUI">
+                                        <rect key="frame" x="0.0" y="444" width="182" height="34"/>
+                                        <state key="normal" title="Secondary highlighted"/>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="NO"/>
+                                        </userDefinedRuntimeAttributes>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jbE-un-BvP" customClass="FancyButton" customModule="WordPressUI">
+                                        <rect key="frame" x="0.0" y="518" width="182" height="34"/>
+                                        <state key="normal" title="Secondary disabled"/>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="YES"/>
+                                        </userDefinedRuntimeAttributes>
+                                    </button>
+                                </subviews>
+                            </stackView>
+                        </subviews>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <constraints>
+                            <constraint firstItem="4IX-T0-GRU" firstAttribute="centerX" secondItem="O2a-cZ-0ji" secondAttribute="centerX" id="cF8-1m-2mC"/>
+                            <constraint firstItem="4IX-T0-GRU" firstAttribute="centerY" secondItem="O2a-cZ-0ji" secondAttribute="centerY" id="mrV-bV-4yf"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="O2a-cZ-0ji"/>
+                    </view>
+                    <navigationItem key="navigationItem" id="QQQ-hf-TLL"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="VM9-7T-6w0" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="566" y="445"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="wp4-lm-2pf">
             <objects>
                 <navigationController id="PbN-Bb-478" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="Wjr-vl-1MQ">
-                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <connections>

--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -28,7 +28,11 @@ class ViewController: UITableViewController
                     self.showFancyAlertWithSwitch()
                 })]
             ),
-            DemoSection(title: "Misc UI Elements", rows: []),
+            DemoSection(title: "Misc UI Elements", rows: [
+                DemoRow(title: "Fancy Buttons", action: {
+                    self.showFancyButtons()
+                })
+            ]),
         ]
     }
     
@@ -100,6 +104,12 @@ class ViewController: UITableViewController
         })
         
         showFancyAlert(switchConfig: switchConfig)
+    }
+
+    // MARK: - Fancy Buttons
+
+    func showFancyButtons() {
+        performSegue(withIdentifier: "FancyButtonsSegue", sender: self)
     }
     
     // MARK: - Test Messages for the User
@@ -184,3 +194,5 @@ struct DemoRow {
     var title: String
     var action: RowAction
 }
+
+class FancyButtonsViewController: UIViewController {}

--- a/WordPressUI.podspec
+++ b/WordPressUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressUI"
-  s.version       = "1.3.5"
+  s.version       = "1.4-beta.1"
   s.summary       = "Home of reusable WordPress UI components."
 
   s.description   = <<-DESC

--- a/WordPressUI/Extensions/UIImage+Assets.swift
+++ b/WordPressUI/Extensions/UIImage+Assets.swift
@@ -33,15 +33,13 @@ extension UIImage {
         return Bundle.wordPressUIBundle
     }
 
-    /// Renders the Background Image with the specified Background + Size + Radius + Insets parameters.
+    /// Renders the Background Image with the specified Background + Size + Insets parameters.
     ///
     public class func renderBackgroundImage(fill: UIColor,
-                               border: UIColor,
+                               border: UIColor? = nil,
                                size: CGSize = DefaultRenderMetrics.backgroundImageSize,
                                cornerRadius: CGFloat = DefaultRenderMetrics.backgroundCornerRadius,
-                               capInsets: UIEdgeInsets = DefaultRenderMetrics.backgroundCapInsets,
-                               shadowOffset: CGSize = DefaultRenderMetrics.backgroundShadowOffset,
-                               shadowBlurRadius: CGFloat = DefaultRenderMetrics.backgroundShadowBlurRadius) -> UIImage {
+                               capInsets: UIEdgeInsets = DefaultRenderMetrics.backgroundCapInsets) -> UIImage {
 
         let renderer = UIGraphicsImageRenderer(size: size)
         let image = renderer.image { context in
@@ -54,23 +52,24 @@ extension UIImage {
             var bounds = renderer.format.bounds
             bounds.origin.x += lineWidthInPixels
             bounds.origin.y += lineWidthInPixels
-            bounds.size.height -= lineWidthInPixels * 2 + shadowOffset.height
-            bounds.size.width -= lineWidthInPixels * 2 + shadowOffset.width
+            bounds.size.height -= lineWidthInPixels * 2
+            bounds.size.width -= lineWidthInPixels * 2
 
             let path = UIBezierPath(roundedRect: bounds, cornerRadius: cornerRadius)
 
             /// Draw: Background + Shadow
             cgContext.saveGState()
-            cgContext.setShadow(offset: shadowOffset, blur: shadowBlurRadius, color: border.cgColor)
+
             fill.setFill()
 
             path.fill()
 
             cgContext.restoreGState()
 
-            /// Draw: Border!
-            border.setStroke()
-            path.stroke()
+            if let border = border {
+                border.setStroke()
+                path.stroke()
+            }
         }
 
         return image.resizableImage(withCapInsets: capInsets)
@@ -82,8 +81,6 @@ extension UIImage {
         public static let backgroundImageSize = CGSize(width: 44, height: 44)
         public static let backgroundCornerRadius = CGFloat(8)
         public static let backgroundCapInsets = UIEdgeInsets(top: 18, left: 18, bottom: 18, right: 18)
-        public static let backgroundShadowOffset = CGSize(width: 0, height: 2)
-        public static let backgroundShadowBlurRadius = CGFloat(0)
         public static let contentInsets = UIEdgeInsets(top: 12, left: 20, bottom: 12, right: 20)
     }
 }

--- a/WordPressUI/FancyAlert/FancyButton.swift
+++ b/WordPressUI/FancyAlert/FancyButton.swift
@@ -13,7 +13,7 @@ open class FancyButton: UIButton {
             configureBackgrounds()
         }
     }
-    @objc public dynamic var primaryNormalBorderColor = Primary.normalBorderColor {
+    @objc public dynamic var primaryNormalBorderColor: UIColor? = nil {
         didSet {
             configureBackgrounds()
         }
@@ -26,7 +26,7 @@ open class FancyButton: UIButton {
             configureBackgrounds()
         }
     }
-    @objc public dynamic var primaryHighlightBorderColor = Primary.highlightBorderColor {
+    @objc public dynamic var primaryHighlightBorderColor: UIColor? = nil {
         didSet {
             configureBackgrounds()
         }
@@ -185,9 +185,7 @@ private extension FancyButton {
     ///
     struct Primary {
         static let normalBackgroundColor = UIColor(red: 0x00/255.0, green: 0xAA/255.0, blue: 0xDC/255.0, alpha: 0xFF/255.0)
-        static let normalBorderColor = UIColor(red: 0x00/255.0, green: 0x87/255.0, blue: 0xBE/255.0, alpha: 0xFF/255.0)
         static let highlightBackgroundColor = UIColor(red: 0x00/255.0, green: 0x87/255.0, blue: 0xBE/255.0, alpha: 0xFF/255.0)
-        static let highlightBorderColor = normalBorderColor
     }
 
     /// Style: Secondary


### PR DESCRIPTION
Refs https://github.com/wordpress-mobile/WordPress-iOS/issues/12592.

This PR updates FancyButtons to have no drop shadow, and no border unless they're secondary buttons. I also added a new example screen to show the various fancy button styles.

The new styles are intended to look like this, however the colors in the example app won't match:

![Buttons (1)](https://user-images.githubusercontent.com/4780/66327050-0bf0c880-e922-11e9-84a5-5db7abca218a.png)

You can use [this WordPress iOS PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/12640) to verify in the WordPress app. You can also view the Fancy Buttons example in the example app.

![Simulator Screen Shot - iPhone Xʀ - 2019-10-07 at 15 01 09](https://user-images.githubusercontent.com/4780/66328365-64c16080-e924-11e9-99e4-f469a5aa56fb.png)
