### PR TITLE
Renaming md5 method to resolve conflict with the same WPKit method.

### DIFF
--- a/WordPressUI.podspec
+++ b/WordPressUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressUI"
-  s.version       = "1.4"
+  s.version       = "1.5-beta.1"
   s.summary       = "Home of reusable WordPress UI components."
 
   s.description   = <<-DESC

--- a/WordPressUI.xcodeproj/project.pbxproj
+++ b/WordPressUI.xcodeproj/project.pbxproj
@@ -156,7 +156,7 @@
 		B5C82AE22077C01B00DB2E78 /* UILabel+SuggestSize.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UILabel+SuggestSize.h"; sourceTree = "<group>"; };
 		B5C82AE42077C02100DB2E78 /* UILabel+SuggestSize.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UILabel+SuggestSize.m"; sourceTree = "<group>"; };
 		B5D91457206AD8BA00EF333D /* FancyButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FancyButton.swift; sourceTree = "<group>"; };
-		FF20AD1620B76A2300082398 /* WordPressUI.podspec */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = WordPressUI.podspec; sourceTree = "<group>"; };
+		FF20AD1620B76A2300082398 /* WordPressUI.podspec */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = WordPressUI.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */

--- a/WordPressUI/Extensions/Gravatar/Gravatar.swift
+++ b/WordPressUI/Extensions/Gravatar/Gravatar.swift
@@ -4,7 +4,6 @@ public struct Gravatar {
     fileprivate struct Defaults {
         static let scheme = "https"
         static let host = "secure.gravatar.com"
-        // unknownHash = md5("unknown@gravatar.com")
         static let unknownHash = "ad516503a11cd5ca435acc9bb6523536"
     }
 

--- a/WordPressUI/Extensions/Gravatar/NSString+Gravatar.h
+++ b/WordPressUI/Extensions/Gravatar/NSString+Gravatar.h
@@ -2,6 +2,6 @@
 
 @interface NSString (Gravatar)
 
-- (NSString *)md5;
+- (NSString *)md5Hash;
 
 @end

--- a/WordPressUI/Extensions/Gravatar/NSString+Gravatar.m
+++ b/WordPressUI/Extensions/Gravatar/NSString+Gravatar.m
@@ -4,7 +4,7 @@
 
 @implementation NSString (Gravatar)
 
-- (NSString *)md5
+- (NSString *)md5Hash
 {
     const char *cStr = [self UTF8String];
     unsigned char result[CC_MD5_DIGEST_LENGTH];

--- a/WordPressUI/Extensions/UIImageView+Gravatar.swift
+++ b/WordPressUI/Extensions/UIImageView+Gravatar.swift
@@ -213,7 +213,7 @@ extension UIImageView {
         return email
             .lowercased()
             .trimmingCharacters(in: .whitespaces)
-            .md5()
+            .md5Hash()
     }
 
     /// Returns the required gravatar size. If the current view's size is zero, falls back to the default size.


### PR DESCRIPTION
Ref WPiOS issue: https://github.com/wordpress-mobile/WordPress-iOS/issues/10975

This renames the `md5` method to `md5Hash` to resolve a conflict with the same method in `WordPressKit`.

Can be tested with WPiOS PR: TBD