### PR TITLE
Add accessibility identifiers for FancyAlertView

### DIFF
--- a/WordPressUI/FancyAlert/FancyAlertViewController.swift
+++ b/WordPressUI/FancyAlert/FancyAlertViewController.swift
@@ -264,6 +264,9 @@ open class FancyAlertViewController: UIViewController {
         update(alertView.titleAccessoryButton, with: configuration.titleAccessoryButton)
         updateBottomSwitch(with: configuration.switchConfig)
 
+        alertView.defaultButton.accessibilityIdentifier = "fancy-alert-view-default-button"
+        alertView.cancelButton.accessibilityIdentifier = "fancy-alert-view-cancel-button"
+
         // If we have no title accessory button, we need to
         // disable the trailing constraint to allow the title to flow correctly
         alertView.titleAccessoryButtonTrailingConstraint.isActive = (configuration.titleAccessoryButton != nil)

--- a/WordPressUI/FancyAlert/FancyAlerts.storyboard
+++ b/WordPressUI/FancyAlert/FancyAlerts.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14865.1" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="ZA1-84-qnC">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="ZA1-84-qnC">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14819.2"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -137,7 +137,6 @@
                                                                 <subviews>
                                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wFm-sT-H6c" userLabel="Never Button" customClass="FancyButton" customModule="WordPressUI">
                                                                         <rect key="frame" x="0.0" y="0.0" width="84.5" height="34"/>
-                                                                        <accessibility key="accessibilityConfiguration" identifier="cancelAlertButton"/>
                                                                         <state key="normal" title="Not Now"/>
                                                                         <userDefinedRuntimeAttributes>
                                                                             <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="NO"/>
@@ -148,7 +147,6 @@
                                                                     </button>
                                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qlO-59-AKI" customClass="FancyButton" customModule="WordPressUI">
                                                                         <rect key="frame" x="104.5" y="0.0" width="85" height="34"/>
-                                                                        <accessibility key="accessibilityConfiguration" identifier="cancelAlertButton"/>
                                                                         <state key="normal" title="Not Now"/>
                                                                         <userDefinedRuntimeAttributes>
                                                                             <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="NO"/>
@@ -159,7 +157,6 @@
                                                                     </button>
                                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Bju-kg-VqX" customClass="FancyButton" customModule="WordPressUI">
                                                                         <rect key="frame" x="209.5" y="0.0" width="84.5" height="34"/>
-                                                                        <accessibility key="accessibilityConfiguration" identifier="defaultAlertButton"/>
                                                                         <state key="normal" title="Try It"/>
                                                                         <userDefinedRuntimeAttributes>
                                                                             <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="YES"/>


### PR DESCRIPTION
Fixes a bug in using accessibility identifiers with `FancyAlertView` buttons by applying them when the `FancyAlertView` is configured.

In some cases, they wouldn't be accessible the old way, where they were defined in the storyboard, but applying them from the code fixes this issue. It's _possible_ this could be related to the fact that the `never` and `cancel` buttons both used the same accessibility ID, but the error wasn't about an ambiguous element, it was about not being able to find it. In any case, now it's only applied to the cancel button.

Tests pass in both projects, so I think this is an ok approach. Let me know if you disagree?

**To Review**
- Ensure the code looks sensible
- Ensure that all tests pass in this PR, [as well as this one](https://github.com/wordpress-mobile/WordPress-iOS/pull/11240/files).
