### PR TITLE
Fixes an issue with the image download URL being improperly cached.

### DIFF
--- a/WordPressUI.podspec
+++ b/WordPressUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressUI"
-  s.version       = "1.5.2"
+  s.version       = "1.5.3-beta.1"
   s.summary       = "Home of reusable WordPress UI components."
 
   s.description   = <<-DESC

--- a/WordPressUI/Extensions/UIImageView+Networking.swift
+++ b/WordPressUI/Extensions/UIImageView+Networking.swift
@@ -64,6 +64,7 @@ public extension UIImageView {
 
         let internalOnSuccess = { [weak self] (image: UIImage) in
             self?.image = image
+            self?.downloadURL  = url
             success?(image)
         }
 
@@ -79,7 +80,6 @@ public extension UIImageView {
 
         // Do this first, if there was any ongoing task for this imageview we need to cancel imediately or else we can apply the cache image and not cancel a previous download
         cancelImageDownload()
-        downloadURL = url
 
         if let image = cachedImage {
             internalOnSuccess(image)


### PR DESCRIPTION
The image download URL was being improperly cached, preventing the image from being downloaded if there was a failure on the first try.