### PR TITLE
Fixes issue: image not set at first download

### DIFF
--- a/WordPressUI.podspec
+++ b/WordPressUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressUI"
-  s.version       = "1.5.3"
+  s.version       = "1.5.4-beta.1"
   s.summary       = "Home of reusable WordPress UI components."
 
   s.description   = <<-DESC

--- a/WordPressUI.podspec
+++ b/WordPressUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressUI"
-  s.version       = "1.5.4-beta.1"
+  s.version       = "1.6.0-beta.1"
   s.summary       = "Home of reusable WordPress UI components."
 
   s.description   = <<-DESC

--- a/WordPressUI/Extensions/UIImageView+Networking.swift
+++ b/WordPressUI/Extensions/UIImageView+Networking.swift
@@ -99,7 +99,7 @@ public extension UIImageView {
             DispatchQueue.main.async {
                 Downloader.cache.setObject(image, forKey: url as AnyObject)
 
-                if response?.url == self?.downloadURL {
+                if response?.url == url {
                     internalOnSuccess(image)
                 }
 


### PR DESCRIPTION
Some images (e.g. the gravatar in the new 'Me' button) were not set at the first download, even if the image was cached

Test with [this](https://github.com/wordpress-mobile/WordPress-iOS/pull/13969) WordPress-iOS PR