### PR TITLE
Change FancyButton background image w/ trait change

### DIFF
--- a/WordPressUI.podspec
+++ b/WordPressUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressUI"
-  s.version       = "1.6.0-beta.1"
+  s.version       = "1.6.0-beta.2"
   s.summary       = "Home of reusable WordPress UI components."
 
   s.description   = <<-DESC

--- a/WordPressUI/FancyAlert/FancyButton.swift
+++ b/WordPressUI/FancyAlert/FancyButton.swift
@@ -120,7 +120,11 @@ open class FancyButton: UIButton {
         super.awakeFromNib()
         configureAppearance()
     }
-
+    
+    open override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        configureBackgrounds()
+    }
 
     /// Setup: Everything = [Insets, Backgrounds, titleColor(s), titleLabel]
     ///


### PR DESCRIPTION
**WPiOS**: https://github.com/wordpress-mobile/WordPress-iOS/pull/14042

This fixes an issue with FancyButton not responding to the `userInterfaceStyle` change. The background image used by the button does not automatically respond to the trait change (like a UIColor would), so this method refreshes that image.

## Testing
- Check out and run the branch from https://github.com/wordpress-mobile/WordPress-iOS/pull/14042
- Verify that changing the appearance while the modal is shown properly changes the "Okay" button background.

| Before | After |
|--|--|
| ![FancyButtonBefore](https://user-images.githubusercontent.com/3250/80822631-5ffe1b80-8b98-11ea-8b7c-9c871d0e265c.gif) | ![FancyButtonAfter](https://user-images.githubusercontent.com/3250/80822639-642a3900-8b98-11ea-8733-55ac2438554d.gif) |



Otherwise, the background image is stuck with the wrong user interface style.