### PR TITLE
Adds behavior to pan the Bottom Sheet modal on scroll

### DIFF
--- a/WordPressUI.podspec
+++ b/WordPressUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressUI"
-  s.version       = "1.6.1-beta.1"
+  s.version       = "1.7.0"
   s.summary       = "Home of reusable WordPress UI components."
 
   s.description   = <<-DESC

--- a/WordPressUI.podspec
+++ b/WordPressUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressUI"
-  s.version       = "1.6.0"
+  s.version       = "1.6.1-beta.1"
   s.summary       = "Home of reusable WordPress UI components."
 
   s.description   = <<-DESC

--- a/WordPressUI/BottomSheet/DrawerPresentationController.swift
+++ b/WordPressUI/BottomSheet/DrawerPresentationController.swift
@@ -380,7 +380,7 @@ private extension DrawerPresentationController {
             
             /// When scrolling, we want the drag start point to be reset once the view begins to move down, otherwise the drag start point will be incorrect.
             if isScrolling == true && scrollViewYOffset == 0 && yPosition == expandedYPosition {
-                dragStartPoint = CGPoint.zero
+                dragStartPoint = .zero
                 animated = true /// Animate this transition or else the value will jump
             }
             
@@ -388,7 +388,7 @@ private extension DrawerPresentationController {
             var yTranslation = translation.y
             
             /// Slows the deceleration rate
-            if presentedView.frame.origin.y < expandedYPosition {
+            if isScrolling == true && presentedView.frame.origin.y < expandedYPosition {
                 yTranslation /= 2.0
             }
 
@@ -406,12 +406,12 @@ private extension DrawerPresentationController {
 
             let maxY = topMargin(with: .maxHeight)
             var yPosition = startY + yTranslation
-            if presentableViewController?.scrollableView?.isScrolling == true {
+            if isScrolling == true {
                 /// During scrolling, ensure yPosition doesn't extend past the expanded position
                 yPosition = max(yPosition, expandedYPosition)
             }
+            
             let newMargin = max(yPosition, maxY)
-
             setTopMargin(newMargin, animated: animated)
 
         case .ended:

--- a/WordPressUI/BottomSheet/DrawerPresentationController.swift
+++ b/WordPressUI/BottomSheet/DrawerPresentationController.swift
@@ -372,8 +372,6 @@ private extension DrawerPresentationController {
             dragStartPoint = presentedView.frame.origin
 
         case .changed:
-            var animated = false
-                                    
             let startY = dragStartPoint?.y ?? 0
             var yTranslation = translation.y
             
@@ -402,7 +400,7 @@ private extension DrawerPresentationController {
             }
             
             let newMargin = max(yPosition, maxY)
-            setTopMargin(newMargin, animated: animated)
+            setTopMargin(newMargin, animated: false)
 
         case .ended:
             /// Helper closure to prevent user transition/dismiss

--- a/WordPressUI/BottomSheet/DrawerPresentationController.swift
+++ b/WordPressUI/BottomSheet/DrawerPresentationController.swift
@@ -356,7 +356,7 @@ private extension DrawerPresentationController {
     @objc func pan(_ gesture: UIPanGestureRecognizer) {
         guard let presentedView = self.presentedView else { return }
         
-        let isScrolling = presentableViewController?.scrollableView?.isScrolling
+        let isScrolling = presentableViewController?.scrollableView?.isScrolling == true
         
         guard (presentableViewController?.scrollableView?.contentOffset.y ?? 0) <= 0 || isScrolling == false else { return }
         
@@ -371,7 +371,7 @@ private extension DrawerPresentationController {
         case .began:
             /// We don't want to start the pan after a scroll where the pan began, since the scroll has taken place during that gesture.
             /// `dragStartPoint` will be set in the `.changed` case below once scrolling has stopped at the top of the content and panning has begun.
-            if isScrolling == false || yPosition != expandedYPosition {
+            if !isScrolling || yPosition != expandedYPosition {
                 dragStartPoint = presentedView.frame.origin
             }
 
@@ -379,7 +379,7 @@ private extension DrawerPresentationController {
             var animated = false
             
             /// When scrolling, we want the drag start point to be reset once the view begins to move down, otherwise the drag start point will be incorrect.
-            if isScrolling == true && scrollViewYOffset == 0 && yPosition == expandedYPosition {
+            if isScrolling && scrollViewYOffset == 0 && yPosition == expandedYPosition {
                 dragStartPoint = .zero
                 animated = true /// Animate this transition or else the value will jump
             }
@@ -388,7 +388,7 @@ private extension DrawerPresentationController {
             var yTranslation = translation.y
             
             /// Slows the deceleration rate
-            if isScrolling == true && presentedView.frame.origin.y < expandedYPosition {
+            if isScrolling && presentedView.frame.origin.y < expandedYPosition {
                 yTranslation /= 2.0
             }
 
@@ -406,7 +406,7 @@ private extension DrawerPresentationController {
 
             let maxY = topMargin(with: .maxHeight)
             var yPosition = startY + yTranslation
-            if isScrolling == true {
+            if isScrolling {
                 /// During scrolling, ensure yPosition doesn't extend past the expanded position
                 yPosition = max(yPosition, expandedYPosition)
             }


### PR DESCRIPTION
WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14121

This adds behavior to the Bottom Sheet modal to pan up and down when scrolling the content in `scrollableView`.

<a href="https://user-images.githubusercontent.com/3250/81965385-394ad680-95d5-11ea-8b08-add9e3e7dae0.gif"><img src="https://user-images.githubusercontent.com/3250/81965385-394ad680-95d5-11ea-8b08-add9e3e7dae0.gif" width="300"></a>


#### Testing
- Use the WordPress iOS PR
- Navigate to the Reader screen and tap the Filter button
- Filter modal begins compact but expands upon scrolling the content up
- Filter modal switches to compact on scrolling down
- Filter modal dismisses on scrolling further down
- Filter modal will expand or dismiss on "flinging" while scrolling up or down

### Known Issues

- The transition between panning and scrolling can occasionally fail when a scroll view is added during the gesture.