### PR TITLE
Handle dismiss in BottomSheet ChildViewController

### DIFF
--- a/WordPressUI.podspec
+++ b/WordPressUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressUI"
-  s.version       = "1.7.0"
+  s.version       = "1.7.1"
   s.summary       = "Home of reusable WordPress UI components."
 
   s.description   = <<-DESC

--- a/WordPressUI/BottomSheet/BottomSheetViewController.swift
+++ b/WordPressUI/BottomSheet/BottomSheetViewController.swift
@@ -171,6 +171,9 @@ extension BottomSheetViewController: UIViewControllerTransitioningDelegate {
     }
 
     public func animationController(forDismissed dismissed: UIViewController) -> UIViewControllerAnimatedTransitioning? {
+        if let childViewController = childViewController {
+            childViewController.handleDismiss()
+        }
         return BottomSheetAnimationController(transitionType: .dismissing)
     }
 

--- a/WordPressUI/BottomSheet/DrawerPresentationController.swift
+++ b/WordPressUI/BottomSheet/DrawerPresentationController.swift
@@ -56,6 +56,8 @@ public protocol DrawerPresentable: AnyObject {
 
     /// A scroll view that should have its insets adjusted when the drawer is expanded/collapsed
     var scrollableView: UIScrollView? { get }
+
+    func handleDismiss()
 }
 
 private enum Constants {
@@ -125,6 +127,8 @@ public extension DrawerPresentable where Self: UIViewController {
 
         return presentationController ?? navigationPresentationController ?? navParentPresetationController ?? parentPresentationController
     }
+
+    func handleDismiss() { }
 }
 
 public class DrawerPresentationController: FancyAlertPresentationController {


### PR DESCRIPTION
Added function to DrawerPresentableViewController protocol so that childViewController can handle its dismissal via the bottom sheet 