### PR TITLE
Add an optional `UIBarButtonItem` anchor for bottom sheet popover on iPad 

### DIFF
--- a/WordPressUI.podspec
+++ b/WordPressUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressUI"
-  s.version       = "1.7.1"
+  s.version       = "1.7.2-beta.1"
   s.summary       = "Home of reusable WordPress UI components."
 
   s.description   = <<-DESC

--- a/WordPressUI/BottomSheet/BottomSheetViewController.swift
+++ b/WordPressUI/BottomSheet/BottomSheetViewController.swift
@@ -43,12 +43,22 @@ public class BottomSheetViewController: UIViewController {
         super.init(nibName: nil, bundle: nil)
     }
 
-    public func show(from presenting: UIViewController, sourceView: UIView? = nil, arrowDirections: UIPopoverArrowDirection = .any) {
+    /// Presents the bottom sheet given an optional anchor and arrow directions for the popover on iPad.
+    /// - Parameters:
+    ///   - presenting: the view controller that presents the bottom sheet.
+    ///   - sourceView: optional anchor view for the popover on iPad.
+    ///   - sourceBarButtonItem: optional anchor bar button item for the popover on iPad. If non-nil, `sourceView` and `arrowDirections` are not used.
+    ///   - arrowDirections: optional arrow directions for the popover on iPad.
+    public func show(from presenting: UIViewController, sourceView: UIView? = nil, sourceBarButtonItem: UIBarButtonItem? = nil, arrowDirections: UIPopoverArrowDirection = .any) {
         if UIDevice.isPad() {
             modalPresentationStyle = .popover
-            popoverPresentationController?.permittedArrowDirections = arrowDirections
-            popoverPresentationController?.sourceView = sourceView ?? UIView()
-            popoverPresentationController?.sourceRect = sourceView?.bounds ?? .zero
+            if let sourceBarButtonItem = sourceBarButtonItem {
+                popoverPresentationController?.barButtonItem = sourceBarButtonItem
+            } else {
+                popoverPresentationController?.permittedArrowDirections = arrowDirections
+                popoverPresentationController?.sourceView = sourceView ?? UIView()
+                popoverPresentationController?.sourceRect = sourceView?.bounds ?? .zero
+            }
             popoverPresentationController?.backgroundColor = view.backgroundColor
         } else {
             transitioningDelegate = self


### PR DESCRIPTION
Before this PR, we haven't had a use case for anchoring a bottom sheet popover at a `UIBarButtonItem` on iPad. For our new feature, [Products M4 - creating a product](https://github.com/woocommerce/woocommerce-ios/issues/2740), we show a bottom sheet from a `UIBarButtonItem` in the navigation bar and it'd be nice for the popover to anchor at the item on iPad.

In WPiOS, this PR should have no effect because the bottom sheet is shown from a `UIView`/`UIButton` for the existing use cases (see screenshots below).

## Changes

- Updated `BottomSheetViewController`'s `show` function to take in an optional `UIBarButtonItem` so that if this becomes the anchor of the popover on iPad if non-nil.

## Testing

### WPiOS

Please check out [this branch `wordpressui-testing/bottom-sheet-UIBarButtonItem-anchor`](https://github.com/wordpress-mobile/WordPress-iOS/compare/wordpressui-testing/bottom-sheet-UIBarButtonItem-anchor?expand=1) and run `bundle exec pod install`. There are two existing use cases for bottom sheet:

#### Post editor

- Launch the app on iPad
- Log in to a site
- Create a post
- Enter a title
- Tap "Publish" in the navigation bar --> a popover should point to the "Publish" button like before

#### Reader filtering

- Launch the app on iPad
- Navigate to the "Reader" tab
- Tap "Filter" CTA --> a popover should point to the CTA like before

### WCiOS

Please follow the instructions in this PR: https://github.com/woocommerce/woocommerce-ios/pull/2860

## Example screenshots in WCiOS

before | after
-- | --
![Simulator Screen Shot - iPad Air (3rd generation) - 2020-09-23 at 13 25 19](https://user-images.githubusercontent.com/1945542/93972262-84a39b80-fda4-11ea-9c93-ce725d23f797.png) | ![Simulator Screen Shot - iPad Air (3rd generation) - 2020-09-23 at 13 51 13](https://user-images.githubusercontent.com/1945542/93972278-8a997c80-fda4-11ea-9ced-114b1ea76429.png)

## Example screenshots in WPiOS

(There should be no user-facing changes)

screen | before | after
-- | -- | --
Post editor | ![Simulator Screen Shot - iPad Air (3rd generation) - 2020-09-23 at 14 09 25](https://user-images.githubusercontent.com/1945542/93974389-532ccf00-fda8-11ea-8e63-3fc746d3b556.png) | ![Simulator Screen Shot - iPad Air (3rd generation) - 2020-09-23 at 14 16 17](https://user-images.githubusercontent.com/1945542/93974403-5758ec80-fda8-11ea-8ab8-da4679c504d2.png)
Reader | ![Simulator Screen Shot - iPad Air (3rd generation) - 2020-09-23 at 14 10 38](https://user-images.githubusercontent.com/1945542/93974472-6e97da00-fda8-11ea-9c17-282d428b1e43.png) | ![Simulator Screen Shot - iPad Air (3rd generation) - 2020-09-23 at 14 16 35](https://user-images.githubusercontent.com/1945542/93974491-73f52480-fda8-11ea-87af-95898c58824d.png)

