### PR TITLE
[Home Page Picker] Adds error message to url mismatch

### DIFF
--- a/WordPressUI.podspec
+++ b/WordPressUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressUI"
-  s.version       = "1.7.2"
+  s.version       = "1.7.3-beta.1"
   s.summary       = "Home of reusable WordPress UI components."
 
   s.description   = <<-DESC

--- a/WordPressUI/Extensions/UIImageView+Networking.swift
+++ b/WordPressUI/Extensions/UIImageView+Networking.swift
@@ -2,6 +2,9 @@ import Foundation
 
 
 public extension UIImageView {
+    public enum ImageDownloadError: Error {
+        case urlMismatch
+    }
 
     /// Downloads an image and updates the current UIImageView Instance.
     ///
@@ -97,11 +100,12 @@ public extension UIImageView {
             }
 
             DispatchQueue.main.async {
-                Downloader.cache.setObject(image, forKey: url as AnyObject)
-
                 if response?.url == url {
-                    internalOnSuccess(image)
-                }
+                     Downloader.cache.setObject(image, forKey: url as AnyObject)
+                     internalOnSuccess(image)
+                 } else {
+                     failure?(ImageDownloadError.urlMismatch)
+                 }
 
                 self?.downloadTask = nil
             }

--- a/WordPressUI/Extensions/UIImageView+Networking.swift
+++ b/WordPressUI/Extensions/UIImageView+Networking.swift
@@ -2,7 +2,7 @@ import Foundation
 
 
 public extension UIImageView {
-    public enum ImageDownloadError: Error {
+    enum ImageDownloadError: Error {
         case urlMismatch
     }
 


### PR DESCRIPTION
**Related PR**
- `WordPress-iOS`: https://github.com/wordpress-mobile/WordPress-iOS/pull/15252

## Description
Previously when an image URL didn't match the requested URL then the image would be cached but then fail silently. For the Home Page Picker project, this results in a problem because the request gets redirected to a new endpoint as a landing zone for generating the image. This now will prevent the cache and respond back with a URL mismatch error. This allows the client to then poll the URL again to see if the image finished downloading.
