### PR TITLE
[Home Page Picker] Adds behavior to animate showing and hiding of a view

### DIFF
--- a/WordPressUI.podspec
+++ b/WordPressUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressUI"
-  s.version       = "1.7.3"
+  s.version       = "1.7.4-beta.1"
   s.summary       = "Home of reusable WordPress UI components."
 
   s.description   = <<-DESC

--- a/WordPressUI.podspec
+++ b/WordPressUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressUI"
-  s.version       = "1.7.3-beta.2"
+  s.version       = "1.7.4-beta.1"
   s.summary       = "Home of reusable WordPress UI components."
 
   s.description   = <<-DESC

--- a/WordPressUI.podspec
+++ b/WordPressUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressUI"
-  s.version       = "1.7.3-beta.1"
+  s.version       = "1.7.3-beta.2"
   s.summary       = "Home of reusable WordPress UI components."
 
   s.description   = <<-DESC

--- a/WordPressUI/Extensions/UIView+Animations.swift
+++ b/WordPressUI/Extensions/UIView+Animations.swift
@@ -134,6 +134,24 @@ extension UIView {
         })
     }
 
+    /// Applies a Cross Dissolve transition to fade a view to or from visibile then set's the Hidden value to reflect the current alpha's state.
+    ///
+    public func animatableSetIsHidden(_ isHidden: Bool, animated: Bool = true, _ completion: ((Bool) -> Void)? = nil) {
+        guard self.isHidden != isHidden else { return }
+        guard animated else {
+            self.isHidden = isHidden
+            return
+        }
+
+        self.isHidden = false
+        let alpha: CGFloat = isHidden ? UIKitConstants.alphaZero : UIKitConstants.alphaFull
+        UIView.animate(withDuration: Animations.duration, delay: 0, options: .transitionCrossDissolve, animations: {
+            self.alpha = alpha
+        }) { success in
+            self.isHidden = isHidden
+            completion?(success)
+        }
+    }
 
     /// Private Constants
     ///


### PR DESCRIPTION
**Related PRs**
- `WordPress-iOS`:https://github.com/wordpress-mobile/WordPress-iOS/pull/15293

This can be tested with: https://github.com/wordpress-mobile/WordPress-iOS/pull/15293


## To Test

1. Navigate to either Home Page Picker or Modal Layout Picker
1. Select a Design or Layout
- **Expect** a smooth transition of changing the available bottom buttons. 