### PR TITLE
Update the bottom sheet's presented view frame on view layout

### DIFF
--- a/WordPressUI.podspec
+++ b/WordPressUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressUI"
-  s.version       = "1.9.0-beta.1"
+  s.version       = "1.9.0-beta.2"
   s.summary       = "Home of reusable WordPress UI components."
 
   s.description   = <<-DESC

--- a/WordPressUI/BottomSheet/DrawerPresentationController.swift
+++ b/WordPressUI/BottomSheet/DrawerPresentationController.swift
@@ -299,6 +299,7 @@ public class DrawerPresentationController: FancyAlertPresentationController {
 
     override public func containerViewWillLayoutSubviews() {
         super.containerViewWillLayoutSubviews()
+        presentedView?.frame = frameOfPresentedViewInContainerView
 
         addGestures()
         observe(scrollView: presentableViewController?.scrollableView)


### PR DESCRIPTION
Fixes: https://github.com/wordpress-mobile/WordPress-iOS/issues/15531
`containerViewWillLayoutSubviews` gets called when we switch between categories and tags pickers to prepublishing view. 
This PR sets the frame of the presented in that method
![prepublishing_nudges](https://user-images.githubusercontent.com/1335657/102420466-0f1c2580-3fb7-11eb-885f-1b859315bedf.gif)

To test:
1. Update the WordPressUI pod path in pod file to this branch 
2. Test that the prepublishing sheet doesn't get cut at the bottom when switching between views in the bottom sheet
3.  Test on iPad