### PR TITLE
Fixes the bottom sheet view from changing height when presenting a child view controller

### DIFF
--- a/WordPressUI.podspec
+++ b/WordPressUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressUI"
-  s.version       = "1.9.0-beta.1"
+  s.version       = "1.9.0-beta.2"
   s.summary       = "Home of reusable WordPress UI components."
 
   s.description   = <<-DESC

--- a/WordPressUI/BottomSheet/BottomSheetViewController.swift
+++ b/WordPressUI/BottomSheet/BottomSheetViewController.swift
@@ -167,10 +167,18 @@ public class BottomSheetViewController: UIViewController {
     }
 
     @objc func keyboardWillShow(_ notification: NSNotification) {
+        guard childViewController?.presentedViewController == nil else {
+            return
+        }
+
         self.presentedVC?.transition(to: .expanded)
     }
 
     @objc func keyboardWillHide(_ notification: NSNotification) {
+        guard childViewController?.presentedViewController == nil else {
+            return
+        }
+
         self.presentedVC?.transition(to: .collapsed)
     }
 }

--- a/WordPressUI/BottomSheet/DrawerPresentationController.swift
+++ b/WordPressUI/BottomSheet/DrawerPresentationController.swift
@@ -484,7 +484,7 @@ private extension DrawerPresentationController {
             /// Halts scrolling when scrolling down from expanded or up from compact
             haltScrolling(scrollView)
 
-        } else if scrollView.isScrolling || isPresentedViewAnimating {
+        } else if scrollView.isScrolling {
 
             if isPresentedViewAnchored {
                 /// Allow normal scrolling (with tracking)


### PR DESCRIPTION
Fixes: wordpress-mobile/WordPress-iOS#15531

This should be merged in place of: https://github.com/wordpress-mobile/WordPressUI-iOS/pull/80

You can test with: https://github.com/wordpress-mobile/WordPress-iOS/pull/15551

### To Test: 
1. Pull the above PR
2. Launch the app
3. Tap on the My Sites tab
4. Tap on a site
5. Tap the + button
6. Tap on Blog Post
7. Enter some text
8. Tap on Publish
9. Tap on Categories
10. Tap on the + button
11. Tap on Save
12. Verify the Categories height is still collapsed
13. Swipe up to expand it
14. Tap back
15. Verify the main view's height is reset and not cut off
16. Verify all the other options still work

### Bonus Test
1. Tap on the Reader tab
2. Tap on Following
3. Tap on Filter
4. Verify the Sites / Topics view is still working correctly

