### PR TITLE
Push podspec to internal spec repo too

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,40 +4,56 @@ orbs:
   # Using 1.0 of our Orbs means it will use the latest 1.0.x version from https://github.com/wordpress-mobile/circleci-orbs
   ios: wordpress-mobile/ios@1.0
 
+# YAML anchors for some common/repeated values
+x-common-params:
+  - &xcode-version "11.2.1"
+  - &workspace "WordPressUI.xcworkspace"
+  - &ios-version "13.2.2"
+  - &podspec "WordPressUI.podspec"
+  - &on-tags-only
+      tags:
+        only: /.*/
+      branches:
+        ignore: /.*/
+
 workflows:
   test_and_validate:
     jobs:
       - ios/test:
           name: Unit Tests
-          xcode-version: "11.2.1"
-          workspace: WordPressUI.xcworkspace
+          xcode-version: *xcode-version
+          workspace: *workspace
           scheme: WordPressUI
           device: iPhone 11
-          ios-version: "13.2.2"
+          ios-version: *ios-version
           bundle-install: false
           pod-install: false
       - ios/test:
           name: UI Tests
-          xcode-version: "11.2.1"
-          workspace: WordPressUI.xcworkspace
+          xcode-version: *xcode-version
+          workspace: *workspace
           scheme: Example
           device: iPhone 11
-          ios-version: "13.2.2"
+          ios-version: *ios-version
           bundle-install: false
           pod-install: false
       - ios/validate-podspec:
           name: Validate Podspec
-          xcode-version: "11.2.1"
-          podspec-path: WordPressUI.podspec
+          xcode-version: *xcode-version
+          podspec-path: *podspec
           bundle-install: true
       - ios/publish-podspec:
+          name: Publish to a8c Spec Repo
+          xcode-version: *xcode-version
+          podspec-path: *podspec
+          spec-repo: https://github.com/wordpress-mobile/cocoapods-specs.git
+          bundle-install: true
+          post-to-slack: false
+          filters: *on-tags-only
+      - ios/publish-podspec:
           name: Publish to Trunk
-          xcode-version: "11.2.1"
-          podspec-path: WordPressUI.podspec
+          xcode-version: *xcode-version
+          podspec-path: *podspec
           bundle-install: true
           post-to-slack: true
-          filters:
-            tags:
-              only: /.*/
-            branches:
-              ignore: /.*/
+          filters: *on-tags-only


### PR DESCRIPTION
This will make CI push this podspec to our new internal spec repo on tag (in addition to still pushing it to trunk as usual).

Similar to:
 - https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/580
 - https://github.com/wordpress-mobile/WordPressKit-iOS/pull/374
 - https://github.com/wordpress-mobile/WordPress-iOS-Shared/pull/289