### PR TITLE
[Tooling] Standardize podspec format

### DIFF
--- a/WordPressUI.podspec
+++ b/WordPressUI.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
 
   s.homepage      = "https://github.com/wordpress-mobile/WordPressUI-iOS"
   s.license       = { :type => "GPLv2", :file => "LICENSE" }
-  s.author        = { "The WordPress Mobile Team" => "mobile@automattic.com" }
+  s.author        = { "The WordPress Mobile Team" => "mobile@wordpress.org" }
 
   s.platform      = :ios, "11.0"
   s.swift_version = '5.0'

--- a/WordPressUI.podspec
+++ b/WordPressUI.podspec
@@ -7,13 +7,10 @@ Pod::Spec.new do |s|
                     This framework contains standalone and reusable components, brought to you by the WordPress iOS Team.
                     DESC
 
-  s.homepage      = "http://apps.wordpress.com"
+  s.homepage      = "https://github.com/wordpress-mobile/WordPressUI-iOS"
   s.license       = { :type => "GPLv2", :file => "LICENSE" }
-  s.author        = {
-    "Automattic" => "mobile@automattic.com",
-    "Jorge Leandro Perez" => "jorge.perez@automattic.com"
-  }
-  s.social_media_url = "http://twitter.com/WordPressiOS"
+  s.author        = { "Automattic" => "mobile@automattic.com" }
+  s.social_media_url = "https://twitter.com/automattic"
 
   s.platform      = :ios, "11.0"
   s.swift_version = '5.0'
@@ -26,6 +23,5 @@ Pod::Spec.new do |s|
       'WordPressUI/**/*.{storyboard}'
     ]
   }
-  s.requires_arc  = true
   s.header_dir    = 'WordPressUI'
 end

--- a/WordPressUI.podspec
+++ b/WordPressUI.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.summary       = "Home of reusable WordPress UI components."
   s.description   = <<-DESC
                     This framework contains standalone and reusable components, brought to you by the WordPress iOS Team.
-                    DESC
+                  DESC
 
   s.homepage      = "https://github.com/wordpress-mobile/WordPressUI-iOS"
   s.license       = { :type => "GPLv2", :file => "LICENSE" }

--- a/WordPressUI.podspec
+++ b/WordPressUI.podspec
@@ -1,17 +1,23 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressUI"
   s.version       = "1.9.0"
-  s.summary       = "Home of reusable WordPress UI components."
 
+  s.summary       = "Home of reusable WordPress UI components."
   s.description   = <<-DESC
                     This framework contains standalone and reusable components, brought to you by the WordPress iOS Team.
                     DESC
 
   s.homepage      = "http://apps.wordpress.com"
-  s.license       = "GPLv2"
-  s.author        = { "Jorge Leandro Perez" => "jorge.perez@automattic.com" }
+  s.license       = { :type => "GPLv2", :file => "LICENSE" }
+  s.author        = {
+    "Automattic" => "mobile@automattic.com",
+    "Jorge Leandro Perez" => "jorge.perez@automattic.com"
+  }
+  s.social_media_url = "http://twitter.com/WordPressiOS"
+
   s.platform      = :ios, "11.0"
   s.swift_version = '5.0'
+
   s.source        = { :git => "https://github.com/wordpress-mobile/WordPressUI-iOS.git", :tag => s.version.to_s }
   s.source_files  = 'WordPressUI/**/*.{h,m,swift}'
   s.resource_bundles = {

--- a/WordPressUI.podspec
+++ b/WordPressUI.podspec
@@ -9,8 +9,7 @@ Pod::Spec.new do |s|
 
   s.homepage      = "https://github.com/wordpress-mobile/WordPressUI-iOS"
   s.license       = { :type => "GPLv2", :file => "LICENSE" }
-  s.author        = { "Automattic" => "mobile@automattic.com" }
-  s.social_media_url = "https://twitter.com/automattic"
+  s.author        = { "The WordPress Mobile Team" => "mobile@automattic.com" }
 
   s.platform      = :ios, "11.0"
   s.swift_version = '5.0'


### PR DESCRIPTION
As part of paaHJt-Vl-p2, this simply standardize the podspec file so that all our pods use a similar format and structure, with similar keys and common values.

See https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/582 for the rules I decided to follow on the format and content standardization.