### PR TITLE
FancyAlerts: Add new style with padding between image and divider

### DIFF
--- a/WordPressUI.podspec
+++ b/WordPressUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressUI"
-  s.version       = "1.9.0"
+  s.version       = "1.10.0-beta.1"
 
   s.summary       = "Home of reusable WordPress UI components."
   s.description   = <<-DESC

--- a/WordPressUI/FancyAlert/FancyAlertView.swift
+++ b/WordPressUI/FancyAlert/FancyAlertView.swift
@@ -11,6 +11,7 @@ open class FancyAlertView: UIView {
     @IBOutlet weak var headerImageView: UIImageView!
     @IBOutlet weak var headerImageViewTopConstraint: NSLayoutConstraint!
     @IBOutlet weak var headerImageViewBottomConstraint: NSLayoutConstraint!
+    @IBOutlet weak var headerImageViewWrapperTopConstraint: NSLayoutConstraint!
     @IBOutlet weak var headerImageViewWrapperBottomConstraint: NSLayoutConstraint?
     @IBOutlet weak var headerImageWrapperView: UIView!
 

--- a/WordPressUI/FancyAlert/FancyAlertViewController.swift
+++ b/WordPressUI/FancyAlert/FancyAlertViewController.swift
@@ -333,15 +333,19 @@ open class FancyAlertViewController: UIViewController {
 
             alertView.headerImageViewWrapperBottomConstraint?.constant = Constants.headerImageVerticalConstraintRegular
             alertView.buttonWrapperViewTopConstraint?.constant = Constants.headerImageVerticalConstraintRegular
-        case .top, .topWithPadding:
+        case .top:
             alertView.topDividerView.isHiddenInStackView = false
             alertView.bottomDividerView.isHiddenInStackView = true
 
             // the image touches the divider if it is at the top
             alertView.headerImageViewWrapperBottomConstraint?.constant = 0.0
             alertView.buttonWrapperViewTopConstraint?.constant = 0.0
-            fallthrough
         case .topWithPadding:
+            alertView.topDividerView.isHiddenInStackView = false
+            alertView.bottomDividerView.isHiddenInStackView = true
+
+            alertView.headerImageViewWrapperBottomConstraint?.constant = 0.0
+            alertView.buttonWrapperViewTopConstraint?.constant = 0.0
             alertView.headerImageViewTopConstraint.constant = 0.0
             alertView.headerImageViewWrapperTopConstraint.constant = 0.0
         }

--- a/WordPressUI/FancyAlert/FancyAlertViewController.swift
+++ b/WordPressUI/FancyAlert/FancyAlertViewController.swift
@@ -20,6 +20,7 @@ open class FancyAlertViewController: UIViewController {
 
     public enum DividerPosition {
         case top
+        case topWithPadding
         case bottom
     }
 
@@ -69,6 +70,9 @@ open class FancyAlertViewController: UIViewController {
         /// The image displayed at the top of the dialog
         let headerImage: UIImage?
 
+        /// Background color for the header section
+        let headerBackgroundColor: UIColor?
+
         /// The position of the horizontal rule
         let dividerPosition: DividerPosition?
 
@@ -101,6 +105,7 @@ open class FancyAlertViewController: UIViewController {
         public init(titleText: String?,
                     bodyText: String?,
                     headerImage: UIImage?,
+                    headerBackgroundColor: UIColor? = nil,
                     dividerPosition: DividerPosition?,
                     defaultButton: ButtonConfig?,
                     cancelButton: ButtonConfig?,
@@ -114,6 +119,7 @@ open class FancyAlertViewController: UIViewController {
             self.titleText = titleText
             self.bodyText = bodyText
             self.headerImage = headerImage
+            self.headerBackgroundColor = headerBackgroundColor
             self.dividerPosition = dividerPosition
             self.defaultButton = defaultButton
             self.cancelButton = cancelButton
@@ -255,7 +261,7 @@ open class FancyAlertViewController: UIViewController {
 
         updateDivider()
 
-        updateHeaderImage()
+        updateHeader()
 
         update(alertView.defaultButton, with: configuration.defaultButton)
         update(alertView.cancelButton, with: configuration.cancelButton)
@@ -293,7 +299,7 @@ open class FancyAlertViewController: UIViewController {
         UIAccessibility.post(notification: UIAccessibility.Notification.screenChanged, argument: alertView.titleLabel)
     }
 
-    private func updateHeaderImage() {
+    private func updateHeader() {
         if let headerImage = configuration?.headerImage {
             alertView.headerImageView.image = headerImage
             alertView.headerImageWrapperView.isHiddenInStackView = false
@@ -309,15 +315,36 @@ open class FancyAlertViewController: UIViewController {
         } else {
             alertView.headerImageWrapperView.isHiddenInStackView = true
         }
+
+        if let headerBackgroundColor = configuration?.headerBackgroundColor {
+            alertView.headerBackgroundColor = headerBackgroundColor
+        }
     }
 
     private func updateDivider() {
-        alertView.topDividerView.isHiddenInStackView = configuration?.dividerPosition == .bottom
-        alertView.bottomDividerView.isHiddenInStackView = isButtonless || configuration?.dividerPosition == .top
+        guard let dividerPosition = configuration?.dividerPosition else {
+            return
+        }
 
-        // the image touches the divider if it is at the top
-        alertView.headerImageViewWrapperBottomConstraint?.constant = configuration?.dividerPosition == .top ? 0.0 : Constants.headerImageVerticalConstraintRegular
-        alertView.buttonWrapperViewTopConstraint?.constant = configuration?.dividerPosition == .top ? 0.0 : Constants.headerImageVerticalConstraintRegular
+        switch dividerPosition {
+        case .bottom:
+            alertView.topDividerView.isHiddenInStackView = true
+            alertView.bottomDividerView.isHiddenInStackView = isButtonless
+
+            alertView.headerImageViewWrapperBottomConstraint?.constant = Constants.headerImageVerticalConstraintRegular
+            alertView.buttonWrapperViewTopConstraint?.constant = Constants.headerImageVerticalConstraintRegular
+        case .top, .topWithPadding:
+            alertView.topDividerView.isHiddenInStackView = false
+            alertView.bottomDividerView.isHiddenInStackView = true
+
+            // the image touches the divider if it is at the top
+            alertView.headerImageViewWrapperBottomConstraint?.constant = 0.0
+            alertView.buttonWrapperViewTopConstraint?.constant = 0.0
+            fallthrough
+        case .topWithPadding:
+            alertView.headerImageViewTopConstraint.constant = 0.0
+            alertView.headerImageViewWrapperTopConstraint.constant = 0.0
+        }
     }
 
     private func update(_ button: UIButton, with buttonConfig: Config.ButtonConfig?) {

--- a/WordPressUI/FancyAlert/FancyAlerts.storyboard
+++ b/WordPressUI/FancyAlert/FancyAlerts.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="ZA1-84-qnC">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="ZA1-84-qnC">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -69,7 +69,7 @@
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rzT-7k-QCD" userLabel="Content Container">
                                                         <rect key="frame" x="0.0" y="163" width="334" height="172"/>
                                                         <subviews>
-                                                            <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="999" verticalHuggingPriority="999" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rH2-Nt-ZNa">
+                                                            <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="999" verticalHuggingPriority="999" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rH2-Nt-ZNa">
                                                                 <rect key="frame" x="71.5" y="15.5" width="46" height="30"/>
                                                                 <inset key="titleEdgeInsets" minX="0.0" minY="4" maxX="0.0" maxY="4"/>
                                                                 <state key="normal" title="Button"/>
@@ -98,7 +98,7 @@
                                                                         <nil key="textColor"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
-                                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bwf-Ap-GLo">
+                                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bwf-Ap-GLo">
                                                                         <rect key="frame" x="0.0" y="54.5" width="51" height="77.5"/>
                                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                                         <state key="normal" title="Button"/>
@@ -240,6 +240,7 @@
                             <outlet property="headerImageViewBottomConstraint" destination="ZWi-7r-zDG" id="yAS-zo-6nQ"/>
                             <outlet property="headerImageViewTopConstraint" destination="DQh-Mz-Xe8" id="2lF-3H-olA"/>
                             <outlet property="headerImageViewWrapperBottomConstraint" destination="H7l-cv-jTE" id="Ngi-WU-EAx"/>
+                            <outlet property="headerImageViewWrapperTopConstraint" destination="9fD-hk-lWz" id="mqs-oJ-Nl0"/>
                             <outlet property="headerImageWrapperView" destination="zUD-7D-1OQ" id="VWO-PN-oRv"/>
                             <outlet property="mainStackView" destination="hxn-lJ-Q8T" id="7dw-UT-qjI"/>
                             <outlet property="moreInfoButton" destination="bwf-Ap-GLo" id="icj-gN-96T"/>


### PR DESCRIPTION
This PR adds a new style for the dividers in Fancy Alerts. They currently have a `top` and `bottom` style. The top style appears above the text in the alert, but there is no padding between the image and the border. This is used for alerts such as the site address alert in the NUX flow:

<img src="https://user-images.githubusercontent.com/4780/114946805-ccbf0400-9e43-11eb-9b0a-42045c951361.png" width=300>

To support the alert we're displaying for the new custom icons, we need padding below the image. I didn't want to adjust the existing `top` style as that would break existing alerts that use it, so I opted to add a new `topWithPadding` style. Ideally, we should audit all our current uses of fancy alert and rework things so we have one or possibly two main styles that we use throughout the app – perhaps a future hack week project.

The changes here also allow setting a background colour for the top section.

Here's an alert using the new style:

<img src="https://user-images.githubusercontent.com/4780/115013439-f2322900-9ea8-11eb-911a-d73341473db8.png" width=300>

You can test this PR using the associated [WPiOS PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/16322) – see that for testing steps.
