### PR TITLE
Allow FancyButton's text to wrap multiple lines and expand its height

### DIFF
--- a/WordPressUI/FancyAlert/FancyAlerts.storyboard
+++ b/WordPressUI/FancyAlert/FancyAlerts.storyboard
@@ -135,7 +135,7 @@
                                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="Ut8-yb-neA" userLabel="Button Stack View">
                                                                 <rect key="frame" x="20" y="20" width="294" height="34"/>
                                                                 <subviews>
-                                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wFm-sT-H6c" userLabel="Never Button" customClass="FancyButton" customModule="WordPressUI">
+                                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="wordWrap" translatesAutoresizingMaskIntoConstraints="NO" id="wFm-sT-H6c" userLabel="Never Button" customClass="FancyButton" customModule="WordPressUI">
                                                                         <rect key="frame" x="0.0" y="0.0" width="84.5" height="34"/>
                                                                         <state key="normal" title="Not Now"/>
                                                                         <userDefinedRuntimeAttributes>
@@ -145,7 +145,7 @@
                                                                             <action selector="buttonTapped:" destination="ZA1-84-qnC" eventType="touchUpInside" id="r98-Gp-Tb3"/>
                                                                         </connections>
                                                                     </button>
-                                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qlO-59-AKI" customClass="FancyButton" customModule="WordPressUI">
+                                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="wordWrap" translatesAutoresizingMaskIntoConstraints="NO" id="qlO-59-AKI" customClass="FancyButton" customModule="WordPressUI">
                                                                         <rect key="frame" x="104.5" y="0.0" width="85" height="34"/>
                                                                         <state key="normal" title="Not Now"/>
                                                                         <userDefinedRuntimeAttributes>
@@ -155,7 +155,7 @@
                                                                             <action selector="buttonTapped:" destination="ZA1-84-qnC" eventType="touchUpInside" id="Sze-Qf-vhW"/>
                                                                         </connections>
                                                                     </button>
-                                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Bju-kg-VqX" customClass="FancyButton" customModule="WordPressUI">
+                                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="wordWrap" translatesAutoresizingMaskIntoConstraints="NO" id="Bju-kg-VqX" customClass="FancyButton" customModule="WordPressUI">
                                                                         <rect key="frame" x="209.5" y="0.0" width="84.5" height="34"/>
                                                                         <state key="normal" title="Try It"/>
                                                                         <userDefinedRuntimeAttributes>

--- a/WordPressUI/FancyAlert/FancyButton.swift
+++ b/WordPressUI/FancyAlert/FancyButton.swift
@@ -126,6 +126,31 @@ open class FancyButton: UIButton {
         configureBackgrounds()
     }
 
+    // This implementation is required to allow the text of a button to
+    // wrap appropriately including insets above and below.
+    //
+    open override var intrinsicContentSize: CGSize {
+        guard let titleLabel = titleLabel else {
+            return super.intrinsicContentSize
+        }
+
+        let horizontalInsets = contentEdgeInsets.left + contentEdgeInsets.right
+        let verticalInsets = contentEdgeInsets.top + contentEdgeInsets.bottom
+
+        var size = titleLabel.sizeThatFits(CGSize(width: titleLabel.preferredMaxLayoutWidth - horizontalInsets,
+                                                  height: .greatestFiniteMagnitude))
+        size.width += horizontalInsets
+        size.height += verticalInsets
+
+        return size
+    }
+
+    open override func layoutSubviews() {
+        titleLabel?.preferredMaxLayoutWidth = bounds.width
+
+        super.layoutSubviews()
+    }
+
     /// Setup: Everything = [Insets, Backgrounds, titleColor(s), titleLabel]
     ///
     private func configureAppearance() {


### PR DESCRIPTION
This PR makes some tweaks to FancyButton to allow it to wrap multiple lines and expand its height to match if no explicit height constraint has been set.

Please see the associated WordPress-iOS PR for testing steps: https://github.com/wordpress-mobile/WordPress-iOS/pull/16444