### PR TITLE
Issues/bottom sheet preferred content size

### DIFF
--- a/WordPressUI.podspec
+++ b/WordPressUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressUI"
-  s.version       = "1.10.1-beta.2"
+  s.version       = "1.11.1-beta.2"
 
   s.summary       = "Home of reusable WordPress UI components."
   s.description   = <<-DESC

--- a/WordPressUI.podspec
+++ b/WordPressUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressUI"
-  s.version       = "1.10.1-beta.1"
+  s.version       = "1.10.1-beta.2"
 
   s.summary       = "Home of reusable WordPress UI components."
   s.description   = <<-DESC

--- a/WordPressUI/BottomSheet/BottomSheetViewController.swift
+++ b/WordPressUI/BottomSheet/BottomSheetViewController.swift
@@ -140,15 +140,29 @@ public class BottomSheetViewController: UIViewController {
     override public var preferredContentSize: CGSize {
         set {
             childViewController?.preferredContentSize = newValue
+            // Continue to make the assignment via super so preferredContentSizeDidChange is called on iPad popovers, resizing them as needed.
+            super.preferredContentSize = computePaddedPreferredContentSize()
         }
         get {
-            var preferredContentSizePlusAdditionalMargin = (childViewController?.preferredContentSize ?? super.preferredContentSize)
-            // Add additional height only if preferred content size exists. Othwerwise, default popover sizing breaks.
-            if preferredContentSizePlusAdditionalMargin.height != 0 {
-                preferredContentSizePlusAdditionalMargin.height += BottomSheetViewController.Constants.additionalContentTopMargin
-            }
-            return preferredContentSizePlusAdditionalMargin
+            return computePaddedPreferredContentSize()
         }
+    }
+
+    func computePaddedPreferredContentSize() -> CGSize {
+        var preferredContentSizePlusAdditionalMargin = (childViewController?.preferredContentSize ?? super.preferredContentSize)
+        // Add additional height only if preferred content size exists. Othwerwise, default popover sizing breaks.
+        if preferredContentSizePlusAdditionalMargin.height != 0 {
+            preferredContentSizePlusAdditionalMargin.height += BottomSheetViewController.Constants.additionalContentTopMargin
+        }
+        return preferredContentSizePlusAdditionalMargin
+    }
+
+    public override func preferredContentSizeDidChange(forChildContentContainer container: UIContentContainer) {
+        super.preferredContentSizeDidChange(forChildContentContainer: container)
+        // Update our preferred size in response to a child updating theres.
+        // While this leads to a recursive call, the sizes are the same preventing a loop.
+        // The assignment is needed in order for iPad popovers to correctly resize.
+        preferredContentSize = container.preferredContentSize
     }
 
     override public func accessibilityPerformEscape() -> Bool {


### PR DESCRIPTION
This PR updates how the BottomSheet handles its preferredContentSize property.  The change is necessary to support resizing content displayed inside a bottomsheet in a popover, when the geometry of the content is not immediately known. 

This change can be tested with https://github.com/wordpress-mobile/WordPress-iOS/pull/16474 

@frosty would you be game to take a quick peek at these changes as well. I think this is code you're familiar with and I would like to be super sure the changes do not introduce a sneaky sneaky regression. 