### PR TITLE
Improves bottom sheet accessibility with larger font sizes

### DIFF
--- a/WordPressUI.podspec
+++ b/WordPressUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressUI"
-  s.version       = "1.11.0-beta.2"
+  s.version       = "1.11.0-beta.3"
 
   s.summary       = "Home of reusable WordPress UI components."
   s.description   = <<-DESC

--- a/WordPressUI.podspec
+++ b/WordPressUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressUI"
-  s.version       = "1.11.0"
+  s.version       = "1.12.0-beta.1"
 
   s.summary       = "Home of reusable WordPress UI components."
   s.description   = <<-DESC

--- a/WordPressUI/BottomSheet/BottomSheetViewController.swift
+++ b/WordPressUI/BottomSheet/BottomSheetViewController.swift
@@ -133,6 +133,8 @@ public class BottomSheetViewController: UIViewController {
 
     override public var preferredContentSize: CGSize {
         set {
+            childViewController?.view.layoutIfNeeded()
+
             childViewController?.preferredContentSize = newValue
             // Continue to make the assignment via super so preferredContentSizeDidChange is called on iPad popovers, resizing them as needed.
             super.preferredContentSize = computePaddedPreferredContentSize()

--- a/WordPressUI/BottomSheet/BottomSheetViewController.swift
+++ b/WordPressUI/BottomSheet/BottomSheetViewController.swift
@@ -10,8 +10,8 @@ public class BottomSheetViewController: UIViewController {
         /// The height of the space above the bottom sheet content, including the grip view and space around it.
         ///
         public static let additionalContentTopMargin: CGFloat = BottomSheetViewController.Constants.gripHeight
-        + BottomSheetViewController.Constants.Header.spacing
-                    + BottomSheetViewController.Constants.Stack.insets.top
+            + BottomSheetViewController.Constants.Header.spacing
+            + BottomSheetViewController.Constants.Stack.insets.top
 
         enum Header {
             static let spacing: CGFloat = 16

--- a/WordPressUI/BottomSheet/BottomSheetViewController.swift
+++ b/WordPressUI/BottomSheet/BottomSheetViewController.swift
@@ -7,12 +7,6 @@ public class BottomSheetViewController: UIViewController {
         static let buttonSpacing: CGFloat = 8
         static let minimumWidth: CGFloat = 300
 
-        /// The height of the space above the bottom sheet content, including the grip view and space around it.
-        ///
-        public static let additionalContentTopMargin: CGFloat = BottomSheetViewController.Constants.gripHeight
-            + BottomSheetViewController.Constants.Header.spacing
-            + BottomSheetViewController.Constants.Stack.insets.top
-
         enum Header {
             static let spacing: CGFloat = 16
             static let insets: UIEdgeInsets = UIEdgeInsets(top: 0, left: 18, bottom: 0, right: 18)
@@ -149,12 +143,7 @@ public class BottomSheetViewController: UIViewController {
     }
 
     func computePaddedPreferredContentSize() -> CGSize {
-        var preferredContentSizePlusAdditionalMargin = (childViewController?.preferredContentSize ?? super.preferredContentSize)
-        // Add additional height only if preferred content size exists. Othwerwise, default popover sizing breaks.
-        if preferredContentSizePlusAdditionalMargin.height != 0 {
-            preferredContentSizePlusAdditionalMargin.height += BottomSheetViewController.Constants.additionalContentTopMargin
-        }
-        return preferredContentSizePlusAdditionalMargin
+        return (childViewController?.preferredContentSize ?? super.preferredContentSize)
     }
 
     public override func preferredContentSizeDidChange(forChildContentContainer container: UIContentContainer) {

--- a/WordPressUI/BottomSheet/BottomSheetViewController.swift
+++ b/WordPressUI/BottomSheet/BottomSheetViewController.swift
@@ -7,6 +7,12 @@ public class BottomSheetViewController: UIViewController {
         static let buttonSpacing: CGFloat = 8
         static let minimumWidth: CGFloat = 300
 
+        /// The height of the space above the bottom sheet content, including the grip view and space around it.
+        ///
+        public static let additionalContentTopMargin: CGFloat = BottomSheetViewController.Constants.gripHeight
+        + BottomSheetViewController.Constants.Header.spacing
+                    + BottomSheetViewController.Constants.Stack.insets.top
+
         enum Header {
             static let spacing: CGFloat = 16
             static let insets: UIEdgeInsets = UIEdgeInsets(top: 0, left: 18, bottom: 0, right: 18)

--- a/WordPressUI/BottomSheet/BottomSheetViewController.swift
+++ b/WordPressUI/BottomSheet/BottomSheetViewController.swift
@@ -45,7 +45,14 @@ public class BottomSheetViewController: UIViewController {
     ///   - arrowDirections: optional arrow directions for the popover on iPad.
     public func show(from presenting: UIViewController, sourceView: UIView? = nil, sourceBarButtonItem: UIBarButtonItem? = nil, arrowDirections: UIPopoverArrowDirection = .any) {
         if UIDevice.isPad() {
-            modalPresentationStyle = .popover
+            // If the user is using a larger text option we'll display the content in a sheet since
+            // the font may be too large to display in a popover
+            if traitCollection.preferredContentSizeCategory.isAccessibilityCategory {
+                modalPresentationStyle = .formSheet
+            } else {
+                modalPresentationStyle = .popover
+            }
+
             if let sourceBarButtonItem = sourceBarButtonItem {
                 popoverPresentationController?.barButtonItem = sourceBarButtonItem
             } else {
@@ -53,6 +60,7 @@ public class BottomSheetViewController: UIViewController {
                 popoverPresentationController?.sourceView = sourceView ?? UIView()
                 popoverPresentationController?.sourceRect = sourceView?.bounds ?? .zero
             }
+
             popoverPresentationController?.backgroundColor = view.backgroundColor
         } else {
             transitioningDelegate = self

--- a/WordPressUI/BottomSheet/BottomSheetViewController.swift
+++ b/WordPressUI/BottomSheet/BottomSheetViewController.swift
@@ -151,14 +151,14 @@ public class BottomSheetViewController: UIViewController {
 
             childViewController?.preferredContentSize = newValue
             // Continue to make the assignment via super so preferredContentSizeDidChange is called on iPad popovers, resizing them as needed.
-            super.preferredContentSize = computePaddedPreferredContentSize()
+            super.preferredContentSize = computePreferredContentSize()
         }
         get {
-            return computePaddedPreferredContentSize()
+            return computePreferredContentSize()
         }
     }
 
-    func computePaddedPreferredContentSize() -> CGSize {
+    func computePreferredContentSize() -> CGSize {
         return (childViewController?.preferredContentSize ?? super.preferredContentSize)
     }
 

--- a/WordPressUI/BottomSheet/DrawerPresentationController.swift
+++ b/WordPressUI/BottomSheet/DrawerPresentationController.swift
@@ -506,6 +506,11 @@ private extension DrawerPresentationController {
     /// Stops scrolling behavior on `scrollView` and anchors to `scrollViewYOffset`.
     /// - Parameter scrollView: The scroll view to stop and anchor anchor
     private func haltScrolling(_ scrollView: UIScrollView) {
+        // Only halt the scrolling if we haven't halted it before
+        guard scrollView.showsVerticalScrollIndicator else {
+            return
+        }
+
         scrollView.setContentOffset(CGPoint(x: 0, y: scrollViewYOffset), animated: false)
         scrollView.showsVerticalScrollIndicator = false
     }

--- a/WordPressUI/BottomSheet/DrawerPresentationController.swift
+++ b/WordPressUI/BottomSheet/DrawerPresentationController.swift
@@ -274,6 +274,9 @@ public class DrawerPresentationController: FancyAlertPresentationController {
             topMargin = safeAreaInsets.top
 
         case .intrinsicHeight:
+            // Force a layout to make sure we get the correct size from the views
+            presentedViewController.view.layoutIfNeeded()
+
             let height = presentedViewController.preferredContentSize.height
             topMargin = calculatedTopMargin(for: height)
 


### PR DESCRIPTION
**WPiOS Related PR:** https://github.com/wordpress-mobile/WordPress-iOS/pull/16501

This PR does the following:
- Improves the intrinsic content calculations by calling `layoutIfNeeded` on the presented view before asking for the `preferredContentSize`. 
- On iPad if the user has a "larger font" enabled the bottom sheet will be presented as a `formSheet` to prevent any clipping issues in the popover
- This also removes the padding in the `computePaddedPreferredContentSize` since it is adding too much extra height to the bottom of the views. The `additionalContentTopMargin` is left in to maintain compatibility with Woo iOS

### WPiOS Testing Steps:

Follow the steps in the related PR:
- https://github.com/wordpress-mobile/WordPress-iOS/pull/16501

### WooCommerce iOS Testing Steps
1. Edit the PodFile to point to this branch
2. Launch the app on iPhone
3. Tap the Products tab
4. Tap the 'Sort By' option
5. Verify the bottom sheet opens and is not cut off
6. Tap the 'Add Product' button or `+` button  
5. Verify the bottom sheet opens and is not cut off
6. Increase the font size using the steps in the related PR
7. Verify the bottom sheets open and are not cut off
8. Increase the font size to the larger text size
9. Verify the bottom sheet opens and is not cut off
10. Repeat the steps on iPad
11. When enabling the larger text size
12. Verify the view is opened as a sheet in the middle of the screen