### PR TITLE
Addresses a difference between BottomSheetVC's way of handle dismissals across device types.

### DIFF
--- a/WordPressUI.podspec
+++ b/WordPressUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressUI"
-  s.version       = "1.12.0"
+  s.version       = "1.12.1-beta.1"
 
   s.summary       = "Home of reusable WordPress UI components."
   s.description   = <<-DESC

--- a/WordPressUI/BottomSheet/BottomSheetViewController.swift
+++ b/WordPressUI/BottomSheet/BottomSheetViewController.swift
@@ -67,6 +67,7 @@ public class BottomSheetViewController: UIViewController {
                 popoverPresentationController?.sourceRect = sourceView?.bounds ?? .zero
             }
 
+            popoverPresentationController?.delegate = self
             popoverPresentationController?.backgroundColor = view.backgroundColor
         } else {
             transitioningDelegate = self
@@ -208,9 +209,9 @@ extension BottomSheetViewController: UIViewControllerTransitioningDelegate {
     }
 
     public func animationController(forDismissed dismissed: UIViewController) -> UIViewControllerAnimatedTransitioning? {
-        if let childViewController = childViewController {
-            childViewController.handleDismiss()
-        }
+
+        handleDismiss()
+
         return BottomSheetAnimationController(transitionType: .dismissing)
     }
 
@@ -239,5 +240,17 @@ extension BottomSheetViewController: DrawerPresentable {
 
     public var scrollableView: UIScrollView? {
         return childViewController?.scrollableView
+    }
+
+    public func handleDismiss() {
+        if let childViewController = childViewController {
+            childViewController.handleDismiss()
+        }
+    }
+}
+
+extension BottomSheetViewController: UIPopoverPresentationControllerDelegate {
+    public func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+        handleDismiss()
     }
 }


### PR DESCRIPTION
Found an issue that  was causing `DrawerPresentable.handleDismiss()` not to be called on iPad when dismissing a bottom sheet.

The issue was first spotted here: https://github.com/wordpress-mobile/WordPress-iOS/pull/16649#issuecomment-859525318

WordPress iOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/16672

## Testing:

Please refer to the WPiOS PR for testing instructions.