### PR TITLE
Allow bottom sheet children to override supportedInterfaceOrientation

### DIFF
--- a/WordPressUI.podspec
+++ b/WordPressUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressUI"
-  s.version       = "1.13.0-beta.2"
+  s.version       = "1.12.1-beta.2"
 
   s.summary       = "Home of reusable WordPress UI components."
   s.description   = <<-DESC

--- a/WordPressUI.podspec
+++ b/WordPressUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressUI"
-  s.version       = "1.12.0"
+  s.version       = "1.13.0-beta.1"
 
   s.summary       = "Home of reusable WordPress UI components."
   s.description   = <<-DESC

--- a/WordPressUI/BottomSheet/BottomSheetViewController.swift
+++ b/WordPressUI/BottomSheet/BottomSheetViewController.swift
@@ -31,6 +31,10 @@ public class BottomSheetViewController: UIViewController {
 
     private var customHeaderSpacing: CGFloat?
 
+    public override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        return childViewController?.supportedInterfaceOrientations ?? super.supportedInterfaceOrientations
+    }
+
     /// Additional safe are insets for regular horizontal size class
     public var additionalSafeAreaInsetsRegular: UIEdgeInsets = .zero
 


### PR DESCRIPTION
This PR allows the bottom sheet view controller to return its childViewController's value for `supportedInterfaceOrientations` if it defines one. This can allow specific bottom sheets to not rotate if necessary.

See the associated WPiOS PR for testing steps: https://github.com/wordpress-mobile/WordPress-iOS/pull/16683