### PR TITLE
Setup RuboCop and address violations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org' do
   gem 'cocoapods', '~> 1.8.0'
+  gem 'rubocop', '~> 1.18'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,6 @@
-source 'https://rubygems.org' do
-  gem 'cocoapods', '~> 1.8.0'
-  gem 'rubocop', '~> 1.18'
-end
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gem 'cocoapods', '~> 1.8.0'
+gem 'rubocop', '~> 1.18'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,4 @@
 GEM
-  specs:
-
-GEM
   remote: https://rubygems.org/
   specs:
     CFPropertyList (3.0.1)
@@ -100,8 +97,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  cocoapods (~> 1.8.0)!
-  rubocop (~> 1.18)!
+  cocoapods (~> 1.8.0)
+  rubocop (~> 1.18)
 
 BUNDLED WITH
    2.2.21

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,6 +13,7 @@ GEM
     algoliasearch (1.27.1)
       httpclient (~> 2.8, >= 2.8.3)
       json (>= 1.5.1)
+    ast (2.4.2)
     atomos (0.1.3)
     claide (1.0.3)
     cocoapods (1.8.4)
@@ -65,10 +66,29 @@ GEM
     nanaimo (0.2.6)
     nap (1.1.0)
     netrc (0.11.0)
+    parallel (1.20.1)
+    parser (3.0.1.1)
+      ast (~> 2.4.1)
+    rainbow (3.0.0)
+    regexp_parser (2.1.1)
+    rexml (3.2.5)
+    rubocop (1.18.1)
+      parallel (~> 1.10)
+      parser (>= 3.0.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.7.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.7.0)
+      parser (>= 3.0.1.1)
     ruby-macho (1.4.0)
+    ruby-progressbar (1.11.0)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
+    unicode-display_width (2.0.0)
     xcodeproj (1.13.0)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
@@ -81,6 +101,7 @@ PLATFORMS
 
 DEPENDENCIES
   cocoapods (~> 1.8.0)!
+  rubocop (~> 1.18)!
 
 BUNDLED WITH
-   2.2.19
+   2.2.21

--- a/WordPressUI.podspec
+++ b/WordPressUI.podspec
@@ -1,20 +1,22 @@
-Pod::Spec.new do |s|
-  s.name          = "WordPressUI"
-  s.version       = "1.12.1"
+# forzen_string_literal: true
 
-  s.summary       = "Home of reusable WordPress UI components."
+Pod::Spec.new do |s|
+  s.name          = 'WordPressUI'
+  s.version       = '1.12.1'
+
+  s.summary       = 'Home of reusable WordPress UI components.'
   s.description   = <<-DESC
                     This framework contains standalone and reusable components, brought to you by the WordPress iOS Team.
-                  DESC
+  DESC
 
-  s.homepage      = "https://github.com/wordpress-mobile/WordPressUI-iOS"
-  s.license       = { :type => "GPLv2", :file => "LICENSE" }
-  s.author        = { "The WordPress Mobile Team" => "mobile@wordpress.org" }
+  s.homepage      = 'https://github.com/wordpress-mobile/WordPressUI-iOS'
+  s.license       = { type: 'GPLv2', file: 'LICENSE' }
+  s.author        = { 'The WordPress Mobile Team' => 'mobile@wordpress.org' }
 
-  s.platform      = :ios, "11.0"
+  s.platform      = :ios, '11.0'
   s.swift_version = '5.0'
 
-  s.source        = { :git => "https://github.com/wordpress-mobile/WordPressUI-iOS.git", :tag => s.version.to_s }
+  s.source        = { git: 'https://github.com/wordpress-mobile/WordPressUI-iOS.git', tag: s.version.to_s }
   s.source_files  = 'WordPressUI/**/*.{h,m,swift}'
   s.resource_bundles = {
     'WordPressUIResources': [
@@ -22,5 +24,5 @@ Pod::Spec.new do |s|
       'WordPressUI/**/*.{storyboard}'
     ]
   }
-  s.header_dir    = 'WordPressUI'
+  s.header_dir = 'WordPressUI'
 end


### PR DESCRIPTION
I started working with the `.podspec` as part of the WordPress iOS release train conductor role. My editor has been nagging me about the Ruby style used here, so I thought I'd address the warnings.

I decided to also add RuboCop to the Gemfile so that we can all use the same version if we're to make changes to the setup.