### PR TITLE
Issue/wordpress 14926 incorrect author gravatar

### DIFF
--- a/WordPressUI.podspec
+++ b/WordPressUI.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressUI'
-  s.version       = '1.12.1'
+  s.version       = '1.12.2-beta.1'
 
   s.summary       = 'Home of reusable WordPress UI components.'
   s.description   = <<-DESC

--- a/WordPressUI/Extensions/UIImageView+Gravatar.swift
+++ b/WordPressUI/Extensions/UIImageView+Gravatar.swift
@@ -72,7 +72,7 @@ extension UIImageView {
     }
 
     /// Configures the UIImageView to listen for changes to the gravatar it is displaying
-    private func listenForGravatarChanges(forEmail trackedEmail: String) {        
+    private func listenForGravatarChanges(forEmail trackedEmail: String) {
         if let currentObersver = gravatarWrapper?.observer {
             NotificationCenter.default.removeObserver(currentObersver)
             gravatarWrapper = nil

--- a/WordPressUI/Extensions/UIImageView+Gravatar.swift
+++ b/WordPressUI/Extensions/UIImageView+Gravatar.swift
@@ -67,27 +67,26 @@ extension UIImageView {
     public func downloadGravatarWithEmail(_ email: String, rating: GravatarRatings = .default, placeholderImage: UIImage = .gravatarPlaceholderImage) {
         let gravatarURL = gravatarUrl(for: email, size: gravatarDefaultSize(), rating: rating)
 
-        listenForGravatarChanges()
+        listenForGravatarChanges(forEmail: email)
         downloadImage(from: gravatarURL, placeholderImage: placeholderImage)
     }
 
     /// Configures the UIImageView to listen for changes to the gravatar it is displaying
-    private func listenForGravatarChanges() {
-        guard gravatarWrapper == nil else {
-            return
+    private func listenForGravatarChanges(forEmail trackedEmail: String) {        
+        if let currentObersver = gravatarWrapper?.observer {
+            NotificationCenter.default.removeObserver(currentObersver)
+            gravatarWrapper = nil
         }
 
         let observer = NotificationCenter.default.addObserver(forName: .GravatarImageUpdateNotification, object: nil, queue: nil) { [weak self] (notification) in
             guard let userInfo = notification.userInfo,
                 let email = userInfo[Defaults.emailKey] as? String,
-                let image = userInfo[Defaults.imageKey] as? UIImage,
-                let downloadURL = self?.downloadURL else {
+                email == trackedEmail,
+                let image = userInfo[Defaults.imageKey] as? UIImage else {
                     return
             }
-            let testHash = self?.gravatarHash(of: email) ?? ""
-            if downloadURL.absoluteString.contains(testHash) {
-                self?.image = image
-            }
+
+            self?.image = image
         }
         gravatarWrapper = GravatarNotificationWrapper(observer: observer)
     }
@@ -167,7 +166,7 @@ extension UIImageView {
             return
         }
 
-        listenForGravatarChanges()
+        listenForGravatarChanges(forEmail: email)
         overrideImageCache(for: gravatarURL, with: image)
     }
 

--- a/WordPressUI/Extensions/UIImageView+Networking.swift
+++ b/WordPressUI/Extensions/UIImageView+Networking.swift
@@ -38,14 +38,14 @@ public extension UIImageView {
         // If the actual URL was nil, at least we set the Placeholder Image. Capicci?
         guard let url = url else {
             cancelImageDownload()
-            
+
             if let placeholderImage = placeholderImage {
                 self.image = placeholderImage
             }
             
             return
         }
-        
+
         let request = self.request(for: url)
         downloadImage(usingRequest: request, placeholderImage: placeholderImage, success: success, failure: failure)
     }
@@ -65,7 +65,7 @@ public extension UIImageView {
             self?.image = image
             success?(image)
         }
-        
+
         guard let url = request.url else {
             if let placeholderImage = placeholderImage {
                 image = placeholderImage

--- a/WordPressUI/Extensions/UIImageView+Networking.swift
+++ b/WordPressUI/Extensions/UIImageView+Networking.swift
@@ -74,12 +74,12 @@ public extension UIImageView {
             failure?(ImageDownloadError.noURLSpecifiedInRequest)
             return
         }
-        
+
         if let cachedImage = Downloader.cache.object(forKey: url as AnyObject) as? UIImage {
             handleSuccess(cachedImage, url)
             return
         }
-        
+
         // Using the placeholder only makes sense if we know we're going to download an image
         // that's not immediately available to us.
         if let placeholderImage = placeholderImage {
@@ -99,7 +99,7 @@ public extension UIImageView {
                 } else {
                     failure?(ImageDownloadError.urlMismatch)
                 }
-                
+
                 self?.downloadTask = nil
             }
         })

--- a/WordPressUI/Extensions/UIImageView+Networking.swift
+++ b/WordPressUI/Extensions/UIImageView+Networking.swift
@@ -42,7 +42,7 @@ public extension UIImageView {
             if let placeholderImage = placeholderImage {
                 self.image = placeholderImage
             }
-            
+
             return
         }
 
@@ -60,7 +60,7 @@ public extension UIImageView {
     ///
     @objc func downloadImage(usingRequest request: URLRequest, placeholderImage: UIImage? = nil, success: ((UIImage) -> ())? = nil, failure: ((Error?) -> ())? = nil) {
         cancelImageDownload()
-        
+
         let handleSuccess = { [weak self] (image: UIImage, url: URL) in
             self?.image = image
             success?(image)
@@ -70,7 +70,7 @@ public extension UIImageView {
             if let placeholderImage = placeholderImage {
                 image = placeholderImage
             }
-            
+
             failure?(ImageDownloadError.noURLSpecifiedInRequest)
             return
         }


### PR DESCRIPTION
Addresses some issues with user images not updating correctly, as reported in https://github.com/wordpress-mobile/WordPress-iOS/issues/14926

Changes:
- Improved Gravatar image updates tracking.
- Removed `downloadURL` since it could potentially get de-synchronized, especially when the placeholder was set.
- We're now cancelling image downloads right away so that there's no chance an ongoing download may overwrite the image we set.

See the WPiOS PR for testing instructions: https://github.com/wordpress-mobile/WordPress-iOS/issues/14926