### PR TITLE
Use correct bundle under Mac Catalyst

### DIFF
--- a/WordPressUI.podspec
+++ b/WordPressUI.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressUI'
-  s.version       = '1.12.2'
+  s.version       = '1.12.3-beta.1'
 
   s.summary       = 'Home of reusable WordPress UI components.'
   s.description   = <<-DESC

--- a/WordPressUI/Extensions/NSBundle+ResourceBundle.swift
+++ b/WordPressUI/Extensions/NSBundle+ResourceBundle.swift
@@ -3,8 +3,8 @@ import Foundation
 extension Bundle {
     @objc public class var wordPressUIBundle: Bundle {
         let defaultBundle = Bundle(for: FancyAlertViewController.self)
-        // If installed with CocoaPods, resources will be in WordPressUI.bundle
         if let resourceBundle = Bundle(url: defaultBundle.bundleURL.appendingPathComponent("WordPressUIResources.bundle")) {
+        // If installed with CocoaPods, resources will be in WordPressUIResources.bundle
             return resourceBundle
         }
         // Otherwise, the default bundle is used for resources

--- a/WordPressUI/Extensions/NSBundle+ResourceBundle.swift
+++ b/WordPressUI/Extensions/NSBundle+ResourceBundle.swift
@@ -3,8 +3,9 @@ import Foundation
 extension Bundle {
     @objc public class var wordPressUIBundle: Bundle {
         let defaultBundle = Bundle(for: FancyAlertViewController.self)
-        if let resourceBundle = Bundle(url: defaultBundle.bundleURL.appendingPathComponent("WordPressUIResources.bundle")) {
         // If installed with CocoaPods, resources will be in WordPressUIResources.bundle
+        if let bundleUrl = defaultBundle.url(forResource: "WordPressUIResources", withExtension: "bundle"),
+           let resourceBundle = Bundle(url: bundleUrl) {
             return resourceBundle
         }
         // Otherwise, the default bundle is used for resources


### PR DESCRIPTION
Closes #105 

## Description

The WooCommerce app was crashing on login and switching stores when run under Mac Catalyst, due to WordPressUI being unable to retrieve a Gravatar placeholder image from its bundle.

The `Assets.car` file was correctly created, and copied into the framework where it should be. Web searches turned up [this CocoaPods issue](https://github.com/CocoaPods/CocoaPods/issues/5477), which led me to [Stream's issue](https://github.com/GetStream/stream-chat-swift/issues/1566) and [their fix for it](https://github.com/GetStream/stream-chat-swift/pull/1602), which was a naming issue of their resources bundle.

I checked the WordPressUI approach to getting the resources bundle, to make sure it was named correctly, and noticed that we used a different call to get the URL, and that the one Stream used looked more specific and avoided concatenation. Further research into this [indicated that the resources paths](https://www.reddit.com/r/swift/comments/4p33iq/comment/d4hpj0b/?utm_source=share&utm_medium=web2x&context=3) for macOS are more complicated than on iOS, so I dug in to what the differences were.

### On macOS
Paths are different using the `appendingPathComponent(_)` function vs the `url(forResource:)` function.
`Bundle(url: Bundle.bundleURL.appendingPathComponent("WordPressUIResources.bundle")`: 
file:///[...]/Build/Products/Debug-maccatalyst/WooCommerce.app/Contents/Frameworks/WordPressUI.framework/WordPressUIResources.bundle – fails

`Bundle.url(forResource:"WordPressUIResources" withExtension: "Bundle")`: 
Optional(file:///[...]/Build/Products/Debug-maccatalyst/WooCommerce.app/Contents/Frameworks/WordPressUI.framework/Resources/WordPressUIResources.bundle/) – works

### On iOS
Both methods return identical paths.
`Bundle(url: Bundle.bundleURL.appendingPathComponent("WordPressUIResources.bundle)"`: 
file:///[...]/WooCommerce.app/Frameworks/WordPressUI.framework/WordPressUIResources.bundle/ – works

`Bundle.url(forResource:"WordPressUIResources" withExtension: "Bundle")`: 
Optional(file:///[...]/WooCommerce.app/Frameworks/WordPressUI.framework/WordPressUIResources.bundle/) – works

## Testing

Using the WooCommerce app under Mac Catalyst from [this commit](https://github.com/woocommerce/woocommerce-ios/commit/e0f604275aa709ef11fde2fa3b238a8fdf86cdd1), attempt to log in or switch stores, and see that the app does not crash.

Repeat the test for iPhone and iOS.

Do the test using a user which has a Gravatar associated with the email, and check that the placeholder is shown before the image is downloaded.