### PR TITLE
Merge 1.12.3 version bump

### DIFF
--- a/WordPressUI.podspec
+++ b/WordPressUI.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressUI'
-  s.version       = '1.12.3-beta.1'
+  s.version       = '1.12.3'
 
   s.summary       = 'Home of reusable WordPress UI components.'
   s.description   = <<-DESC


### PR DESCRIPTION
This version bump PR is part of the code freeze process for WordPress iOS 19.0 and is here to leave a breadcrumb in the release process.