### PR TITLE
Bump version from `1.12.4-beta.1` to `1.12.4` stable

### DIFF
--- a/WordPressUI.podspec
+++ b/WordPressUI.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressUI'
-  s.version       = '1.12.4-beta.1'
+  s.version       = '1.12.4'
 
   s.summary       = 'Home of reusable WordPress UI components.'
   s.description   = <<-DESC


### PR DESCRIPTION
This version bump PR is part of the code freeze workflow for WordPress iOS 19.2 and is here only to leave a breadcrumb in the release process. Once CI is green, I will push the tag for this version and, once that is successfully deployed, admin-merge this.