### PR TITLE
Improve bottom sheet accessibility with label for dismiss button

### DIFF
--- a/WordPressUI.podspec
+++ b/WordPressUI.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressUI'
-  s.version       = '1.12.4'
+  s.version       = '1.12.5-beta.1'
 
   s.summary       = 'Home of reusable WordPress UI components.'
   s.description   = <<-DESC

--- a/WordPressUI/BottomSheet/BottomSheetViewController.swift
+++ b/WordPressUI/BottomSheet/BottomSheetViewController.swift
@@ -95,6 +95,7 @@ public class BottomSheetViewController: UIViewController {
         let button = GripButton()
         button.translatesAutoresizingMaskIntoConstraints = false
         button.addTarget(self, action: #selector(buttonPressed), for: .touchUpInside)
+        button.accessibilityLabel = NSLocalizedString("Dismiss", comment: "Accessibility label for button to dismiss a bottom sheet")
         return button
     }()
 


### PR DESCRIPTION
## Description

This PR improves the bottom sheet accessibility for VoiceOver by adding a "Dismiss" accessibility label to the dismiss button.

## Changes

Adds an accessibility label to the `GripButton` in `BottomSheetViewController`.

## Testing

You can test this change using the steps in this WCiOS PR: https://github.com/woocommerce/woocommerce-ios/pull/6482

## Screenshots

Before|After
-|-
![image](https://user-images.githubusercontent.com/8658164/159551923-fb354907-ad09-4c05-8347-4df33fea339e.png)|![NewOrder-Dismiss](https://user-images.githubusercontent.com/8658164/159551968-2043c2a4-35c6-477a-a7b5-7308ab84d89c.PNG)