### PR TITLE
Allow BottomSheetViewController to work as a modal

### DIFF
--- a/Sources/WordPressUI/BottomSheet/BottomSheetViewController.swift
+++ b/Sources/WordPressUI/BottomSheet/BottomSheetViewController.swift
@@ -241,6 +241,14 @@ extension BottomSheetViewController: DrawerPresentable {
         return childViewController?.allowsUserTransition ?? true
     }
 
+    public var allowsTapToDismiss: Bool {
+        childViewController?.allowsTapToDismiss ?? true
+    }
+
+    public var allowsDragToDismiss: Bool {
+        childViewController?.allowsDragToDismiss ?? true
+    }
+
     public var compactWidth: DrawerWidth {
         childViewController?.compactWidth ?? .percentage(0.66)
     }


### PR DESCRIPTION
# Why

This PR updates the `BottomSheetViewController` type to forward the `allowsTapToDismiss` and `allowsDragToDismiss` properties to its child.

This is useful, for cases where we want the bottom sheet to be un-dismissable when we want it to behave as a modal. 

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
