### PR TITLE
Merge 1.13.0 stable release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format of this document is inspired by [Keep a Changelog](https://keepachang
 When releasing a new version:
 
 1. Remove any empty section (those with `_None._`)
-2. Update the `## Unreleased` header to `## [<version_number>](https://github.com/wordpress-mobile/WordPressUI-iOS/releases/tag/<version_number>)`
+2. Update the `## Unreleased` header to `## <version_number>`
 3. Add a new "Unreleased" section for the next iteration, by copy/pasting the following template:
 
 ## Unreleased

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,11 +38,22 @@ _None._
 
 ### New Features
 
-- Add Swift Package Manager support [#120]
+_None._
 
 ### Bug Fixes
 
 _None._
+
+### Internal Changes
+
+_None._
+
+## 1.13.0
+
+### New Features
+
+- `BottomSheetViewController` can now work modally, too [#126]
+- Add Swift Package Manager support [#120]
 
 ### Internal Changes
 

--- a/WordPressUI.podspec
+++ b/WordPressUI.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressUI'
-  s.version       = '1.12.5'
+  s.version       = '1.13.0'
 
   s.summary       = 'Home of reusable WordPress UI components.'
   s.description   = <<-DESC


### PR DESCRIPTION

This version bump PR is part of the code freeze workflow for WooCommerce iOS [13.9](https://github.com/woocommerce/woocommerce-ios/milestone/150) and is here only to leave a breadcrumb in the release process. Once CI is green, I will push the tag for this version and, once that is successfully deployed, admin-merge this.