### PR TITLE
Fix Crash in BottomSheetViewController due to Incorrect Selector Usage 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,12 @@ _None._
 
 _None._
 
+## 1.13.1
+
+### New Features
+
+- Addresses a crash in the `BottomSheetViewController` that was occurring due to an incorrect usage of a selector. The crash was caused by trying to call the `buttonPressed` instance method as a class method on `BottomSheetViewController.self`.
+
 ## 1.13.0
 
 ### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ _None._
 
 ## 1.13.1
 
-### New Features
+### Bug Fixes
 
 - Addresses a crash in the `BottomSheetViewController` that was occurring due to an incorrect usage of a selector. The crash was caused by trying to call the `buttonPressed` instance method as a class method on `BottomSheetViewController.self`.
 

--- a/Sources/WordPressUI/BottomSheet/BottomSheetViewController.swift
+++ b/Sources/WordPressUI/BottomSheet/BottomSheetViewController.swift
@@ -91,11 +91,11 @@ public class BottomSheetViewController: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
-    private var gripButton: UIButton = {
+    private lazy var gripButton: UIButton = {
         let button = GripButton()
         button.translatesAutoresizingMaskIntoConstraints = false
         button.addTarget(
-            BottomSheetViewController.self,
+            self,
             action: #selector(buttonPressed),
             for: .touchUpInside
         )

--- a/WordPressUI.podspec
+++ b/WordPressUI.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressUI'
-  s.version       = '1.13.0'
+  s.version       = '1.13.1'
 
   s.summary       = 'Home of reusable WordPress UI components.'
   s.description   = <<-DESC


### PR DESCRIPTION
This PR addresses a crash in the `BottomSheetViewController` that was occurring due to incorrect usage of a selector. The crash was caused by trying to call the `buttonPressed` instance method as a class method on `BottomSheetViewController.self`. 

## Changes:

- Changed `var` to `lazy var` for `gripButton` to delay its initialization until it's first used.
- Replaced `BottomSheetViewController.self` with `self` in `addTarget` method to correctly call `buttonPressed` on the current instance of `BottomSheetViewController`.

These changes fix the crash and ensure that the `buttonPressed` method is correctly called when the `gripButton` is pressed. The `dismiss` functionality of the bottom sheet should now work as expected.

## Testing:
- Please ensure to test the `dismiss` functionality of the bottom sheet in various scenarios to confirm the fix. You can test it in this WooCommerce PR: https://github.com/woocommerce/woocommerce-ios/pull/10254

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
