### PR TITLE
Fix an issue with `downloadImage` failure callback being called on the background thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ _None._
 
 -->
 
+## 1.14.1
+
+### Bug Fixes
+
+- Fix an issue with `downloadImage` failure callback being called on the background thread [#130]
+
 ## 1.14.0
 
 ### New Features

--- a/Sources/WordPressUI/Extensions/UIImageView+Networking.swift
+++ b/Sources/WordPressUI/Extensions/UIImageView+Networking.swift
@@ -92,7 +92,10 @@ public extension UIImageView {
 
         let task = URLSession.shared.dataTask(with: request, completionHandler: { [weak self] data, response, error in
             guard let data = data, let image = UIImage(data: data, scale: UIScreen.main.scale) else {
-                failure?(error)
+                DispatchQueue.main.async {
+                    failure?(error)
+                    self?.downloadTask = nil
+                }
                 return
             }
 

--- a/WordPressUI.podspec
+++ b/WordPressUI.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressUI'
-  s.version       = '1.14.0'
+  s.version       = '1.14.1'
 
   s.summary       = 'Home of reusable WordPress UI components.'
   s.description   = <<-DESC


### PR DESCRIPTION
PR for testing: https://github.com/wordpress-mobile/WordPress-iOS/pull/21289

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
