### PR TITLE
Fix an issue with image loader displaying incorrect images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ _None._
 ### Bug Fixes
 
 - Fix an issue with `downloadImage` failure callback being called on the background thread [#130]
+- Fix an issue with `UIImageView-Networking.swift` sometimes displaying incorrect image on view reuse [#131]
 
 ## 1.14.0
 


### PR DESCRIPTION
Related: https://github.com/wordpress-mobile/WordPress-iOS/issues/17972

PR in WP-ios https://github.com/wordpress-mobile/WordPress-iOS/pull/21303

The existing implementation has a pretty obvious issue with the way callbacks are handled.

```
1. Call downloadImage with URL A
2. The download completes and dispatches a completion callback
3. Call downloadImage with URL B
4. The image B is retrieved from the cache and displayed
5. The completion callback for URL A is called and image A is displayed (incorrect image)
```

`URLSession` is fully asynchronous, so there is no guarantee that the callback gets called immediately after cancellation. There are usually multiple queue hops from the point you call `task.cancel()` to the completion callback being called.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
