### PR TITLE
UI Modernization: Extract gravatarUrl to Gravatar

### DIFF
--- a/Sources/WordPressUI/Extensions/Gravatar/Gravatar.swift
+++ b/Sources/WordPressUI/Extensions/Gravatar/Gravatar.swift
@@ -1,10 +1,39 @@
 import Foundation
 
+/// Helper Enum that specifies all of the available Gravatar Image Ratings
+/// TODO: Convert into a pure Swift String Enum. It's done this way to maintain ObjC Compatibility
+///
+@objc
+public enum GravatarRatings: Int {
+    case g
+    case pg
+    case r
+    case x
+    case `default`
+
+    func stringValue() -> String {
+        switch self {
+        case .default:
+            fallthrough
+        case .g:
+            return "g"
+        case .pg:
+            return "pg"
+        case .r:
+            return "r"
+        case .x:
+            return "x"
+        }
+    }
+}
+
 public struct Gravatar {
     fileprivate struct Defaults {
         static let scheme = "https"
         static let host = "secure.gravatar.com"
         static let unknownHash = "ad516503a11cd5ca435acc9bb6523536"
+        static let baseURL = "https://gravatar.com/avatar"
+        static let imageSize = 80
     }
 
     public let canonicalURL: URL
@@ -29,6 +58,35 @@ public struct Gravatar {
         }
 
         return true
+    }
+
+    /// Returns the Gravatar URL, for a given email, with the specified size + rating.
+    ///
+    /// - Parameters:
+    ///     - email: the user's email
+    ///     - size: required download size
+    ///     - rating: image rating filtering
+    ///
+    /// - Returns: Gravatar's URL
+    ///
+    public static func gravatarUrl(for email: String, size: Int? = nil, rating: GravatarRatings = .default) -> URL? {
+        let hash = gravatarHash(of: email)
+        let targetURL = String(format: "%@/%@?d=404&s=%d&r=%@", Defaults.baseURL, hash, size ?? Defaults.imageSize, rating.stringValue())
+        return URL(string: targetURL)
+    }
+
+    /// Returns the gravatar hash of an email
+    ///
+    /// - Parameter email: the email associated with the gravatar
+    /// - Returns: hashed email
+    ///
+    /// This really ought to be in a different place, like Gravatar.swift, but there's
+    /// lots of duplication around gravatars -nh
+    private static func gravatarHash(of email: String) -> String {
+        return email
+            .lowercased()
+            .trimmingCharacters(in: .whitespaces)
+            .md5Hash()
     }
 }
 

--- a/Sources/WordPressUI/Extensions/Gravatar/Gravatar.swift
+++ b/Sources/WordPressUI/Extensions/Gravatar/Gravatar.swift
@@ -27,6 +27,15 @@ public enum GravatarRatings: Int {
     }
 }
 
+/// Helper Enum that specifies some of the options for default images
+/// To see all available options, visit : https://en.gravatar.com/site/implement/images/
+///
+public enum GravatarDefaultImage: String {
+    case fileNotFound = "404"
+    case mp
+    case identicon
+}
+
 public struct Gravatar {
     fileprivate struct Defaults {
         static let scheme = "https"
@@ -38,9 +47,9 @@ public struct Gravatar {
 
     public let canonicalURL: URL
 
-    public func urlWithSize(_ size: Int) -> URL {
+    public func urlWithSize(_ size: Int, defaultImage: GravatarDefaultImage? = nil) -> URL {
         var components = URLComponents(url: canonicalURL, resolvingAgainstBaseURL: false)!
-        components.query = "s=\(size)&d=404"
+        components.query = "s=\(size)&d=\(defaultImage?.rawValue ?? GravatarDefaultImage.fileNotFound.rawValue)"
         return components.url!
     }
 
@@ -69,9 +78,17 @@ public struct Gravatar {
     ///
     /// - Returns: Gravatar's URL
     ///
-    public static func gravatarUrl(for email: String, size: Int? = nil, rating: GravatarRatings = .default) -> URL? {
+    public static func gravatarUrl(for email: String,
+                                   defaultImage: GravatarDefaultImage? = nil,
+                                   size: Int? = nil,
+                                   rating: GravatarRatings = .default) -> URL? {
         let hash = gravatarHash(of: email)
-        let targetURL = String(format: "%@/%@?d=404&s=%d&r=%@", Defaults.baseURL, hash, size ?? Defaults.imageSize, rating.stringValue())
+        let targetURL = String(format: "%@/%@?d=%@&s=%d&r=%@",
+                               Defaults.baseURL,
+                               hash,
+                               defaultImage?.rawValue ?? GravatarDefaultImage.fileNotFound.rawValue,
+                               size ?? Defaults.imageSize,
+                               rating.stringValue())
         return URL(string: targetURL)
     }
 

--- a/Sources/WordPressUI/Extensions/Gravatar/Gravatar.swift
+++ b/Sources/WordPressUI/Extensions/Gravatar/Gravatar.swift
@@ -103,7 +103,7 @@ public struct Gravatar {
         return email
             .lowercased()
             .trimmingCharacters(in: .whitespaces)
-            .md5Hash()
+            .sha256Hash()
     }
 }
 

--- a/Sources/WordPressUI/Extensions/UIImageView+Gravatar.swift
+++ b/Sources/WordPressUI/Extensions/UIImageView+Gravatar.swift
@@ -22,33 +22,6 @@ private class GravatarNotificationWrapper {
 ///
 extension UIImageView {
 
-    /// Helper Enum that specifies all of the available Gravatar Image Ratings
-    /// TODO: Convert into a pure Swift String Enum. It's done this way to maintain ObjC Compatibility
-    ///
-    @objc
-    public enum GravatarRatings: Int {
-        case g
-        case pg
-        case r
-        case x
-        case `default`
-
-        func stringValue() -> String {
-            switch self {
-            case .default:
-                fallthrough
-            case .g:
-                return "g"
-            case .pg:
-                return "pg"
-            case .r:
-                return "r"
-            case .x:
-                return "x"
-            }
-        }
-    }
-
     /// Downloads and sets the User's Gravatar, given his email.
     /// TODO: This is a convenience method. Please, remove once all of the code has been migrated over to Swift.
     ///
@@ -70,7 +43,7 @@ extension UIImageView {
     ///
     @objc
     public func downloadGravatarWithEmail(_ email: String, rating: GravatarRatings = .default, placeholderImage: UIImage = .gravatarPlaceholderImage) {
-        let gravatarURL = gravatarUrl(for: email, size: gravatarDefaultSize(), rating: rating)
+        let gravatarURL = Gravatar.gravatarUrl(for: email, size: gravatarDefaultSize(), rating: rating)
 
         listenForGravatarChanges(forEmail: email)
         downloadImage(from: gravatarURL, placeholderImage: placeholderImage)
@@ -167,7 +140,7 @@ extension UIImageView {
     /// Hope buddah, and the code reviewer, can forgive me for this hack.
     ///
     @objc public func overrideGravatarImageCache(_ image: UIImage, rating: GravatarRatings, email: String) {
-        guard let gravatarURL = gravatarUrl(for: email, size: gravatarDefaultSize(), rating: rating) else {
+        guard let gravatarURL = Gravatar.gravatarUrl(for: email, size: gravatarDefaultSize(), rating: rating) else {
             return
         }
 
@@ -191,35 +164,6 @@ extension UIImageView {
 
     // MARK: - Private Helpers
 
-    /// Returns the Gravatar URL, for a given email, with the specified size + rating.
-    ///
-    /// - Parameters:
-    ///     - email: the user's email
-    ///     - size: required download size
-    ///     - rating: image rating filtering
-    ///
-    /// - Returns: Gravatar's URL
-    ///
-    private func gravatarUrl(for email: String, size: Int, rating: GravatarRatings) -> URL? {
-        let hash = gravatarHash(of: email)
-        let targetURL = String(format: "%@/%@?d=404&s=%d&r=%@", Defaults.baseURL, hash, size, rating.stringValue())
-        return URL(string: targetURL)
-    }
-
-    /// Returns the gravatar hash of an email
-    ///
-    /// - Parameter email: the email associated with the gravatar
-    /// - Returns: hashed email
-    ///
-    /// This really ought to be in a different place, like Gravatar.swift, but there's
-    /// lots of duplication around gravatars -nh
-    private func gravatarHash(of email: String) -> String {
-        return email
-            .lowercased()
-            .trimmingCharacters(in: .whitespaces)
-            .md5Hash()
-    }
-
     /// Returns the required gravatar size. If the current view's size is zero, falls back to the default size.
     ///
     private func gravatarDefaultSize() -> Int {
@@ -235,7 +179,6 @@ extension UIImageView {
     ///
     private struct Defaults {
         static let imageSize = 80
-        static let baseURL = "https://gravatar.com/avatar"
         static var gravatarWrapperKey = "gravatarWrapperKey"
         static let emailKey = "email"
         static let imageKey = "image"

--- a/Sources/WordPressUI/Extensions/UIImageView+Gravatar.swift
+++ b/Sources/WordPressUI/Extensions/UIImageView+Gravatar.swift
@@ -185,6 +185,6 @@ extension UIImageView {
     }
 }
 
-extension NSNotification.Name {
+public extension NSNotification.Name {
     static let GravatarImageUpdateNotification = NSNotification.Name(rawValue: "GravatarImageUpdateNotification")
 }

--- a/Sources/WordPressUIObjC/Extensions/NSString+Gravatar.h
+++ b/Sources/WordPressUIObjC/Extensions/NSString+Gravatar.h
@@ -2,6 +2,6 @@
 
 @interface NSString (Gravatar)
 
-- (NSString *)md5Hash;
+- (NSString *)sha256Hash;
 
 @end

--- a/Sources/WordPressUIObjC/Extensions/NSString+Gravatar.m
+++ b/Sources/WordPressUIObjC/Extensions/NSString+Gravatar.m
@@ -4,18 +4,18 @@
 
 @implementation NSString (Gravatar)
 
-- (NSString *)md5Hash
+- (NSString *)sha256Hash
 {
     const char *cStr = [self UTF8String];
-    unsigned char result[CC_MD5_DIGEST_LENGTH];
+    unsigned char result[CC_SHA256_DIGEST_LENGTH];
 
-    CC_MD5(cStr, (CC_LONG)strlen(cStr), result);
+    CC_SHA256(cStr, (CC_LONG)strlen(cStr), result);
 
-    return [NSString stringWithFormat:
-            @"%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x",
-            result[0], result[1], result[2], result[3], result[4], result[5], result[6], result[7],
-            result[8], result[9], result[10], result[11], result[12], result[13], result[14], result[15]
-            ];
+    NSMutableString *hashString = [NSMutableString stringWithCapacity:CC_SHA256_DIGEST_LENGTH*2];
+    for (int i = 0; i < CC_SHA256_DIGEST_LENGTH; i++) {
+        [hashString appendFormat:@"%02x",result[i]];
+    }
+    return hashString;
 }
 
 @end

--- a/WordPressUI.podspec
+++ b/WordPressUI.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressUI'
-  s.version       = '1.14.1'
+  s.version       = '1.14.2-beta.1'
 
   s.summary       = 'Home of reusable WordPress UI components.'
   s.description   = <<-DESC


### PR DESCRIPTION
## Description

- Extracts `gravatarUrl(for:defaultImage:size:rating)` to `Gravtar.swift`
- Adds a `GravatarDefaultImage` enum 
- Updates to SHA256 hash (ref: pb6Nl-gyD-p2)

## Testing instructions

- Test with https://github.com/wordpress-mobile/WordPress-iOS/pull/21348

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.