### PR TITLE
Merge 1.15.0 stable release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,13 @@ _None._
 
 _None._
 
+## 1.15.0
+
+### New Features
+
+- New `GravatarDefaultImage` and `GravatarRatings` enums available and helper method to get Gravatar URL [#133]
+- Gravatar updated to use SHA256 over MD5 [#133]
+
 ## 1.14.1
 
 ### Bug Fixes

--- a/WordPressUI.podspec
+++ b/WordPressUI.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressUI'
-  s.version       = '1.14.2-beta.1'
+  s.version       = '1.15.0'
 
   s.summary       = 'Home of reusable WordPress UI components.'
   s.description   = <<-DESC


### PR DESCRIPTION
This version bump PR is part of the code freeze workflow for WordPress iOS [23.2](https://github.com/wordpress-mobile/WordPress-iOS/milestones/23.2) and is here only to leave a breadcrumb in the release process. Once CI is green, I will push the tag for this version and, once that is successfully deployed, admin-merge this.