### PR TITLE
Skip inserting ghostable views to subviews of a private UIKit view class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ _None._
 
 ### Bug Fixes
 
-_None._
+- For `UITableViewCell` whose background color is set by `backgroundConfiguration`, the cell now shows the ghost layers only for the content instead of the whole cell. [#138]
 
 ### Internal Changes
 

--- a/Sources/WordPressUI/Ghosts/Internal/UIView+InnerGhost.swift
+++ b/Sources/WordPressUI/Ghosts/Internal/UIView+InnerGhost.swift
@@ -12,7 +12,7 @@ extension UIView {
         layoutIfNeeded()
 
         enumerateGhostableLeafViews { leafView in
-            guard leafView.containsGhostLayer == false && leafView.isPrivateUIKitInstance == false else {
+            guard leafView.containsGhostLayer == false else {
                 return
             }
 
@@ -66,7 +66,7 @@ private extension UIView {
     /// Enumerates all of the receiver's Leaf Views.
     ///
     func enumerateGhostableLeafViews(callback: (UIView) -> ()) {
-        guard !isGhostableDisabled else {
+        guard !isGhostableDisabled && !isPrivateUIKitInstance else {
             return
         }
 


### PR DESCRIPTION
For https://github.com/woocommerce/woocommerce-ios/issues/11701

## Why

After we started configuring the order list table view cell's background color from setting `backgroundColor` to `backgroundConfiguration` in https://github.com/woocommerce/woocommerce-ios/pull/11621, a new background view was added to the cell of type `_UISystemBackgroundView` with a subview `UIView` as shown in the view hierarchy below. However, the current logic in `UIView.insertGhostLayers` that enumerates the ghostable views skips views that are a private UIKit class like `_UISystemBackgroundView` but not its subviews. Because `_UISystemBackgroundView`'s subview is a `UIView`, this background view is considered as ghostable, and thus a ghost layer is added to the background view which makes the cell content not distinguishable.

before | after using backgroundConfiguration
-- | --
<img width="331" alt="Screenshot 2024-01-29 at 3 17 27 PM" src="https://github.com/wordpress-mobile/WordPressUI-iOS/assets/1945542/828cf49d-25f2-42c6-9c1b-de65f8b080e4"> | <img width="330" alt="Screenshot 2024-01-29 at 3 11 40 PM" src="https://github.com/wordpress-mobile/WordPressUI-iOS/assets/1945542/d0888619-2014-4f0f-aa58-037eb38a6115">

## How

First I tried not changing the shared library to minimize the scope of changes, but after trying the following two approaches I think this PR change is the most ideal of all that I can think of. The PR skips UIKit private class subviews so that these internal views don't have ghost layers. Please feel free to share any concerns about this approach, like any scenarios where we might want to add ghost layers to a private UIKit view's subviews. Maybe we can make it a parameter in the ghost option.

I've tried:
- Conforming the table view cell class to `GhostableView` then setting `backgroundConfiguration` to nil in `ghostAnimationWillStart` which is called before inserting ghost layers. This way the background view is removed from the cell. However, there's no equivalent call when the ghost layers are being removed and we need to be careful to ensure that a reload is called. Additionally, because `updateConfiguration(using:)` also sets `backgroundConfiguration` and can be called after  `ghostAnimationWillStart`, `backgroundConfiguration` needs to be checked so that we only set `backgroundConfiguration` when it’s already non-nil. The special logic for ghost view becomes scattered in this cell class
- Subclassing `OrderTableViewCell`, but the cell is currently using xib and it's not trivial to make it work. We'd need to duplicate the xib or have some hacky workarounds

## Testing steps

Please check out the testing instructions in https://github.com/woocommerce/woocommerce-ios/pull/11842.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
