### PR TITLE
Update version to `1.15.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,11 +42,17 @@ _None._
 
 ### Bug Fixes
 
-- For `UITableViewCell` whose background color is set by `backgroundConfiguration`, the cell now shows the ghost layers only for the content instead of the whole cell. [#138]
+_None._
 
 ### Internal Changes
 
 _None._
+
+## 1.15.1
+
+### Bug Fixes
+
+- For `UITableViewCell` whose background color is set by `backgroundConfiguration`, the cell now shows the ghost layers only for the content instead of the whole cell. [#138]
 
 ## 1.15.0
 

--- a/WordPressUI.podspec
+++ b/WordPressUI.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressUI'
-  s.version       = '1.15.0'
+  s.version       = '1.15.1'
 
   s.summary       = 'Home of reusable WordPress UI components.'
   s.description   = <<-DESC


### PR DESCRIPTION
This version bump PR is part of the code freeze workflow for WooCommerce iOS 17.3 and is here only to leave a breadcrumb in the release process. Once CI is green, I will push the tag for this version and, once that is successfully deployed, admin-merge this.