### PR TITLE
Deprecate the Gravatar struct and add some simple alternatives

### DIFF
--- a/Sources/WordPressUI/Extensions/Gravatar/Gravatar.swift
+++ b/Sources/WordPressUI/Extensions/Gravatar/Gravatar.swift
@@ -3,6 +3,7 @@ import Foundation
 /// Helper Enum that specifies all of the available Gravatar Image Ratings
 /// TODO: Convert into a pure Swift String Enum. It's done this way to maintain ObjC Compatibility
 ///
+@available(*, deprecated, message: "Use `GravatarRating` from the Gravatar module.")
 @objc
 public enum GravatarRatings: Int {
     case g
@@ -30,6 +31,7 @@ public enum GravatarRatings: Int {
 /// Helper Enum that specifies some of the options for default images
 /// To see all available options, visit : https://en.gravatar.com/site/implement/images/
 ///
+@available(*, deprecated, message: "Use `DefaultImageOption` from the Gravatar module.")
 public enum GravatarDefaultImage: String {
     case fileNotFound = "404"
     case mp
@@ -40,6 +42,7 @@ internal enum GravatarDefaults {
     static let imageSize = 80
 }
 
+@available(*, deprecated, message: "Use `GravatarURL` from the Gravatar module.")
 public struct Gravatar {
     fileprivate struct Defaults {
         static let scheme = "https"
@@ -50,12 +53,14 @@ public struct Gravatar {
 
     public let canonicalURL: URL
 
+    @available(*, deprecated, message: "Use `GravatarURL.url(with:)` from the Gravatar module.")
     public func urlWithSize(_ size: Int, defaultImage: GravatarDefaultImage? = nil) -> URL {
         var components = URLComponents(url: canonicalURL, resolvingAgainstBaseURL: false)!
         components.query = "s=\(size)&d=\(defaultImage?.rawValue ?? GravatarDefaultImage.fileNotFound.rawValue)"
         return components.url!
     }
 
+    @available(*, deprecated, message: "Use `GravatarURL.isGravatarURL()` from the Gravatar module.")
     public static func isGravatarURL(_ url: URL) -> Bool {
         guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
             return false
@@ -81,7 +86,7 @@ public struct Gravatar {
     ///
     /// - Returns: Gravatar's URL
     ///
-    @available(*, deprecated, message: "Use GravatarURL from Gravatar module instead.")
+    @available(*, deprecated, message: "Use `GravatarURL.url(for:preferredSize:gravatarRating:,defaultImageOption:)`.")
     public static func gravatarUrl(for email: String,
                                    defaultImage: GravatarDefaultImage? = nil,
                                    size: Int? = nil,
@@ -118,6 +123,7 @@ public func ==(lhs: Gravatar, rhs: Gravatar) -> Bool {
 }
 
 public extension Gravatar {
+    @available(*, deprecated, message: "Use `GravatarURL()` from the Gravatar module.")
     init?(_ url: URL) {
         guard Gravatar.isGravatarURL(url) else {
             return nil

--- a/Sources/WordPressUI/Extensions/Gravatar/Gravatar.swift
+++ b/Sources/WordPressUI/Extensions/Gravatar/Gravatar.swift
@@ -36,13 +36,16 @@ public enum GravatarDefaultImage: String {
     case identicon
 }
 
+internal enum GravatarDefaults {
+    static let imageSize = 80
+}
+
 public struct Gravatar {
     fileprivate struct Defaults {
         static let scheme = "https"
         static let host = "secure.gravatar.com"
         static let unknownHash = "ad516503a11cd5ca435acc9bb6523536"
         static let baseURL = "https://gravatar.com/avatar"
-        static let imageSize = 80
     }
 
     public let canonicalURL: URL
@@ -78,6 +81,7 @@ public struct Gravatar {
     ///
     /// - Returns: Gravatar's URL
     ///
+    @available(*, deprecated, message: "Use GravatarURL from Gravatar module instead.")
     public static func gravatarUrl(for email: String,
                                    defaultImage: GravatarDefaultImage? = nil,
                                    size: Int? = nil,
@@ -87,7 +91,7 @@ public struct Gravatar {
                                Defaults.baseURL,
                                hash,
                                defaultImage?.rawValue ?? GravatarDefaultImage.fileNotFound.rawValue,
-                               size ?? Defaults.imageSize,
+                               size ?? GravatarDefaults.imageSize,
                                rating.stringValue())
         return URL(string: targetURL)
     }

--- a/Sources/WordPressUI/Extensions/Gravatar/GravatarURL+Util.swift
+++ b/Sources/WordPressUI/Extensions/Gravatar/GravatarURL+Util.swift
@@ -1,0 +1,23 @@
+import Foundation
+import Gravatar
+
+extension GravatarURL {
+    
+    /// Creates a Gravatar URL. This is the new version of the deprecated method: `Gravatar.gravatarUrl(for:defaultImage:size:rating:)`
+    /// - Parameters:
+    ///   - email: The user's email
+    ///   - preferredSize: Preferred size for the Gravatar image. See: `Gravatar.ImageSize`
+    ///   - gravatarRating: Specifies a Gravatar image rating. See: Gravatar.GravatarRating
+    ///   - defaultImageOption: Option to return a default image if the image requested does not exist. See.Gravatar.DefaultImageOption
+    /// - Returns: Gravatar URL.
+    public static func url(for email: String,
+                           preferredSize: ImageSize? = nil,
+                           gravatarRating: GravatarRating? = nil,
+                           defaultImageOption: DefaultImageOption? = nil) -> URL? {
+        return GravatarURL.gravatarUrl(with: email,
+                                       // Passing GravatarDefaults.imageSize to keep the previous default.
+                                       options: .init(preferredSize: preferredSize ?? .pixels(GravatarDefaults.imageSize),
+                                                      gravatarRating: gravatarRating,
+                                                      defaultImage: defaultImageOption))
+    }
+}

--- a/Sources/WordPressUI/Extensions/Gravatar/GravatarURL+Util.swift
+++ b/Sources/WordPressUI/Extensions/Gravatar/GravatarURL+Util.swift
@@ -15,7 +15,8 @@ extension GravatarURL {
                            gravatarRating: GravatarRating? = nil,
                            defaultImageOption: DefaultImageOption? = nil) -> URL? {
         return GravatarURL.gravatarUrl(with: email,
-                                       // Passing GravatarDefaults.imageSize to keep the previous default.
+                                       // TODO: Passing GravatarDefaults.imageSize to keep the previous default.
+                                       // But ideally this should be passed explicitly.
                                        options: .init(preferredSize: preferredSize ?? .pixels(GravatarDefaults.imageSize),
                                                       gravatarRating: gravatarRating,
                                                       defaultImage: defaultImageOption))


### PR DESCRIPTION
Deprecates public types and methods in `Gravatar.swift`. Adds alternatives as needed. 

Deprecates downloadGravatar(...) that uses the old `Gravatar` struct. Add an equivalent that uses `GravatarURL` instead. 

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
