### PR TITLE
Use Gravatar SDK to download the image via URL

### DIFF
--- a/Sources/WordPressUI/Extensions/UIImageView+Gravatar.swift
+++ b/Sources/WordPressUI/Extensions/UIImageView+Gravatar.swift
@@ -107,11 +107,11 @@ extension UIImageView {
         let options: [GravatarImageSettingOption] = [.imageCache(ImageCache.shared)]
         self.gravatar.setImage(with: url,
                                placeholder: placeholder,
-                               options: options) { result in
+                               options: options) { [weak self] result in
             switch result {
             case .success:
                 if animate {
-                    self.fadeInAnimation()
+                    self?.fadeInAnimation()
                 }
             case .failure(let error):
                 failure?(error)

--- a/Sources/WordPressUI/Extensions/UIImageView+Gravatar.swift
+++ b/Sources/WordPressUI/Extensions/UIImageView+Gravatar.swift
@@ -95,8 +95,6 @@ extension UIImageView {
             return
         }
         
-        //TODO: Ideally use the Gravatar API to download the image.
-
         // Starting with iOS 10, it seems `initWithCoder` uses a default size
         // of 1000x1000, which was messing with our size calculations for gravatars
         // on newly created table cells.
@@ -105,21 +103,20 @@ extension UIImageView {
 
         let size = Int(ceil(frame.width * UIScreen.main.scale))
         let url = gravatar.url(with: .init(preferredSize: .pixels(size)))
-
-        self.downloadImage(from: url,
-                           placeholderImage: placeholder,
-                           success: { image in
-                            guard image != self.image else {
-                                return
-                            }
-
-                            self.image = image
-                            if animate {
-                                self.fadeInAnimation()
-                            }
-        }, failure: { error in
-            failure?(error)
-        })
+        
+        let options: [GravatarImageSettingOption] = [.imageCache(ImageCache.shared)]
+        self.gravatar.setImage(with: url,
+                               placeholder: placeholder,
+                               options: options) { result in
+            switch result {
+            case .success:
+                if animate {
+                    self.fadeInAnimation()
+                }
+            case .failure(let error):
+                failure?(error)
+            }
+        }
     }
 
     /// Downloads the provided Gravatar.

--- a/Sources/WordPressUI/Extensions/UIImageView+Networking.swift
+++ b/Sources/WordPressUI/Extensions/UIImageView+Networking.swift
@@ -1,5 +1,6 @@
 import Foundation
 import UIKit
+import protocol Gravatar.GravatarImageCaching
 
 #if SWIFT_PACKAGE
 import WordPressUIObjC
@@ -172,7 +173,7 @@ public extension UIImageView {
     }
 }
 
-public protocol ImageCaching {
+public protocol ImageCaching: GravatarImageCaching {
     func setImage(_ image: UIImage, forKey key: String)
     func getImage(forKey key: String) -> UIImage?
 }


### PR DESCRIPTION
Use Gravatar SDK to download the image via URL.

Changing the implementation of our new method 

```
public func downloadGravatar(_ gravatar: GravatarURL?, placeholder: UIImage, animate: Bool, failure: ((Error?) -> ())? = nil) 
```

Test:

Impacted files in the WP repo:

- [ ] ListTableViewCell
- [ ] CommentContentTableViewCell
- [ ] NoteBlockCommentTableViewCell
- [ ] NoteBlockHeaderTableViewCell
- [ ] NoteBlockUserTableViewCell
- [ ] PeopleCell
- [ ] PersonViewController
- [ ] RevisionsTableViewCell
NotificationContentView (I haven't figured how we can test this yet.)

Documentation of testing steps can be found here: https://github.com/wordpress-mobile/WordPress-iOS/issues/22543#issuecomment-1948014118 Please take a look and see if you can find anything odd. For now the avatars should be loading successfully. 

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
