### PR TITLE
Use Gravatar.ImageCaching protocol instead of defining our own

### DIFF
--- a/Sources/WordPressUI/Extensions/UIImageView+Networking.swift
+++ b/Sources/WordPressUI/Extensions/UIImageView+Networking.swift
@@ -1,6 +1,6 @@
 import Foundation
 import UIKit
-import protocol Gravatar.ImageCaching
+@_exported import protocol Gravatar.ImageCaching
 
 #if SWIFT_PACKAGE
 import WordPressUIObjC

--- a/Sources/WordPressUI/Extensions/UIImageView+Networking.swift
+++ b/Sources/WordPressUI/Extensions/UIImageView+Networking.swift
@@ -1,6 +1,6 @@
 import Foundation
 import UIKit
-import protocol Gravatar.GravatarImageCaching
+import protocol Gravatar.ImageCaching
 
 #if SWIFT_PACKAGE
 import WordPressUIObjC
@@ -171,11 +171,6 @@ public extension UIImageView {
         ///
         static var taskKey = 0x1001
     }
-}
-
-public protocol ImageCaching: GravatarImageCaching {
-    func setImage(_ image: UIImage, forKey key: String)
-    func getImage(forKey key: String) -> UIImage?
 }
 
 public class ImageCache: ImageCaching {


### PR DESCRIPTION
This updates the module so that it implements (and re-exports) the `Gravatar.ImageCaching` protocol instead of a local protocol that conforms to it.

Note that since this preserves the `WordPressUI-iOS` public interfaces, no changes to `WordPress-iOS` should be necessary.

This should be tested via the WordPress-iOS PR that requires it:
https://github.com/wordpress-mobile/WordPress-iOS/pull/22663

Checkout this branch of `WordPressUI-iOS`
Checkout Gravatar branch: https://github.com/Automattic/Gravatar-SDK-iOS/pull/50
Checkout WordPress-iOS task/gravatar-integration branch: https://github.com/wordpress-mobile/WordPress-iOS/tree/task/gravatar-integration

Follow the steps mentioned here: https://github.com/wordpress-mobile/WordPress-iOS/issues/22543#issuecomment-1956744840

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
