### PR TITLE
Setup SwiftLint in the project and on CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -29,6 +29,15 @@ steps:
   #################
   # Lint
   #################
+  - label: ":swift: SwiftLint"
+    command: run_swiftlint --strict
+    plugins: *common_plugins
+    notify:
+      - github_commit_status:
+          context: "SwiftLint"
+    agents:
+      queue: "default"
+
   - label: "🧹 Lint"
     key: "lint"
     command: |

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 # Nodes with values to reuse in the pipeline.
 common_params:
   plugins: &common_plugins
-    - automattic/a8c-ci-toolkit#3.0.1
+    - automattic/a8c-ci-toolkit#3.1.0
   env: &common_env
     IMAGE_ID: xcode-15.2
 

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -30,4 +30,3 @@ only_rules:
   - vertical_whitespace
   - void_return
   - weak_delegate
-  

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,33 @@
+swiftlint_version: 0.54.0
+
+excluded:
+  - DerivedData
+  - fastlane
+  - vendor
+
+# Rules – Opt-in only, so we can progressively introduce new ones
+#
+only_rules:
+  - colon
+  - comma
+  - comment_spacing
+  - control_statement
+  - discarded_notification_center_observer
+  - duplicate_imports
+  - empty_enum_arguments
+  - empty_parameters
+  - mark
+  - opening_brace
+  - overridden_super_call
+  - redundant_optional_initialization
+  - statement_position
+  - trailing_comma
+  - trailing_newline
+  - trailing_semicolon
+  - trailing_whitespace
+  - unneeded_break_in_switch
+  - unused_closure_parameter
+  - vertical_whitespace
+  - void_return
+  - weak_delegate
+  

--- a/Example/Example/AppDelegate.swift
+++ b/Example/Example/AppDelegate.swift
@@ -5,7 +5,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
 
-
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true
@@ -33,6 +32,4 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
     }
 
-
 }
-

--- a/Example/Example/KeyboardAnimationsExampleViewController.swift
+++ b/Example/Example/KeyboardAnimationsExampleViewController.swift
@@ -36,7 +36,7 @@ class KeyboardAnimationsExampleViewController: UIViewController {
         }
 
         let willHideObserver = NotificationCenter.default.addObserver(forName: UIResponder.keyboardWillHideNotification, object: nil, queue: .main) { (notification) in
-            UIView.animate(withKeyboard: notification) { (beginFrame, endFrame) in
+            UIView.animate(withKeyboard: notification) { (_, _) in
                 self.bottomConstraintForAnimation.constant = 20
                 self.view.setNeedsLayout()
                 self.view.layoutIfNeeded()

--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -3,19 +3,18 @@ import WordPressUI
 
 ///
 ///
-class ViewController: UITableViewController
-{
-    
-    private typealias CompletionClosure = () -> ()
-    
+class ViewController: UITableViewController {
+
+    private typealias CompletionClosure = () -> Void
+
     let cellIdentifier = "CellIdentifier"
     var sections: [DemoSection]!
-    
+
     // MARK: LifeCycle Methods
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         sections = [
             DemoSection(title: "Fancy Alert", rows: [
                 DemoRow(title: "Fancy Alert", action: {
@@ -40,36 +39,36 @@ class ViewController: UITableViewController
             ])
         ]
     }
-    
+
     // MARK: - Useful constants
-    
+
     private struct FancyAlertConstants {
         static let title = "Fancy Alert"
         static let message = "Introducing the Fancy Alert UI Experience. Designed to show alerts and information to the user in a standardized manner."
-        
+
         static let defaultButtonTitle =  "Go Ahead"
         static let cancelButtonTitle = "Cancel"
         static let moreInfoButtonTitle = "More Information"
-        
+
         static let switchText = "Do not show this again"
     }
-    
+
     // MARK: Fancy Alert
-    
+
     func showFancyAlert(moreInfoButton: FancyAlertViewController.Config.ButtonConfig? = nil,
                         switchConfig: FancyAlertViewController.Config.SwitchConfig? = nil) {
-        
-        let defaultButton = FancyAlertViewController.Config.ButtonConfig(FancyAlertConstants.defaultButtonTitle) { (controller: FancyAlertViewController, button: UIButton) in
-            
+
+        let defaultButton = FancyAlertViewController.Config.ButtonConfig(FancyAlertConstants.defaultButtonTitle) { (controller: FancyAlertViewController, _: UIButton) in
+
             self.show(message: FancyAlertConstants.defaultButtonTitle, from: controller) {
                 controller.dismiss(animated: true)
             }
         }
-        
-        let cancelButton = FancyAlertViewController.Config.ButtonConfig(FancyAlertConstants.cancelButtonTitle) { (controller: FancyAlertViewController, button: UIButton) in
+
+        let cancelButton = FancyAlertViewController.Config.ButtonConfig(FancyAlertConstants.cancelButtonTitle) { (controller: FancyAlertViewController, _: UIButton) in
             controller.dismiss(animated: true)
         }
-        
+
         let configuration = FancyAlertViewController.Config(
             titleText: FancyAlertConstants.title,
             bodyText: FancyAlertConstants.message,
@@ -79,23 +78,23 @@ class ViewController: UITableViewController
             cancelButton: cancelButton,
             moreInfoButton: moreInfoButton,
             switchConfig: switchConfig)
-        
+
         let alert = FancyAlertViewController.controllerWithConfiguration(configuration: configuration)
         alert.modalPresentationStyle = .custom
         alert.transitioningDelegate = self
-        
+
         present(alert, animated: true, completion: nil)
     }
-    
+
     func showFancyAlertWithMoreInfo() {
-        let moreInfoButton = FancyAlertViewController.Config.ButtonConfig(FancyAlertConstants.moreInfoButtonTitle) { [unowned self] (controller: FancyAlertViewController, button: UIButton) in
-            
+        let moreInfoButton = FancyAlertViewController.Config.ButtonConfig(FancyAlertConstants.moreInfoButtonTitle) { [unowned self] (controller: FancyAlertViewController, _: UIButton) in
+
             self.show(message: FancyAlertConstants.moreInfoButtonTitle, from: controller)
         }
-        
+
         showFancyAlert(moreInfoButton: moreInfoButton)
     }
-    
+
     func showFancyAlertWithSwitch() {
         let switchConfig = FancyAlertViewController.Config.SwitchConfig(
             initialValue: true,
@@ -107,7 +106,7 @@ class ViewController: UITableViewController
                     self.show(message: "OFF", from: controller)
                 }
         })
-        
+
         showFancyAlert(switchConfig: switchConfig)
     }
 
@@ -116,63 +115,61 @@ class ViewController: UITableViewController
     func showFancyButtons() {
         performSegue(withIdentifier: "FancyButtonsSegue", sender: self)
     }
-    
+
     // MARK: - Test Messages for the User
-    
+
     private func show(message: String, from controller: UIViewController, completion onCompletion: CompletionClosure? = nil) {
         let alertViewController = UIAlertController(title: nil, message: message, preferredStyle: .alert)
-        
-        alertViewController.addActionWithTitle("Ok", style: .default) { alertAction in
+
+        alertViewController.addActionWithTitle("Ok", style: .default) { _ in
             onCompletion?()
         }
-        
+
         controller.present(alertViewController, animated: true, completion: nil)
     }
-    
+
     // MARK: - TableView Methods
-    
+
     override func numberOfSections(in tableView: UITableView) -> Int {
         return sections.count
     }
-    
-    
+
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return sections[section].rows.count
     }
-    
+
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: cellIdentifier)!
         cell.accessoryType = .disclosureIndicator
-        
+
         let row = sections[indexPath.section].rows[indexPath.row]
         cell.textLabel?.text = row.title
-        
+
         return cell
     }
-    
+
     override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
         return 40
     }
-    
+
     override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         let textView = UITextView()
-        
+
         textView.font = UIFont.boldSystemFont(ofSize: 14)
         textView.textAlignment = .center
         textView.isEditable = false
         textView.text = sections[section].title
         textView.backgroundColor = UIColor.lightGray
-        
+
         return textView
     }
-    
-    
+
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
-        
+
         sections[indexPath.section].rows[indexPath.row].action()
     }
-    
+
 }
 
 // MARK: - UIViewControllerTransitioningDelegate
@@ -182,11 +179,10 @@ extension ViewController: UIViewControllerTransitioningDelegate {
         guard presented is FancyAlertViewController else {
             return nil
         }
-        
+
         return FancyAlertPresentationController(presentedViewController: presented, presenting: presenting)
     }
 }
-
 
 typealias RowAction = () -> Void
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,88 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "CollectionConcurrencyKit",
+        "repositoryURL": "https://github.com/JohnSundell/CollectionConcurrencyKit.git",
+        "state": {
+          "branch": null,
+          "revision": "b4f23e24b5a1bff301efc5e70871083ca029ff95",
+          "version": "0.2.0"
+        }
+      },
+      {
+        "package": "CryptoSwift",
+        "repositoryURL": "https://github.com/krzyzanowskim/CryptoSwift.git",
+        "state": {
+          "branch": null,
+          "revision": "7892a123f7e8d0fe62f9f03728b17bbd4f94df5c",
+          "version": "1.8.1"
+        }
+      },
+      {
+        "package": "SourceKitten",
+        "repositoryURL": "https://github.com/jpsim/SourceKitten.git",
+        "state": {
+          "branch": null,
+          "revision": "b6dc09ee51dfb0c66e042d2328c017483a1a5d56",
+          "version": "0.34.1"
+        }
+      },
+      {
+        "package": "swift-argument-parser",
+        "repositoryURL": "https://github.com/apple/swift-argument-parser.git",
+        "state": {
+          "branch": null,
+          "revision": "8f4d2753f0e4778c76d5f05ad16c74f707390531",
+          "version": "1.2.3"
+        }
+      },
+      {
+        "package": "swift-syntax",
+        "repositoryURL": "https://github.com/apple/swift-syntax.git",
+        "state": {
+          "branch": null,
+          "revision": "6ad4ea24b01559dde0773e3d091f1b9e36175036",
+          "version": "509.0.2"
+        }
+      },
+      {
+        "package": "SwiftLint",
+        "repositoryURL": "https://github.com/realm/SwiftLint",
+        "state": {
+          "branch": null,
+          "revision": "f17a4f9dfb6a6afb0408426354e4180daaf49cee",
+          "version": "0.54.0"
+        }
+      },
+      {
+        "package": "SwiftyTextTable",
+        "repositoryURL": "https://github.com/scottrhoyt/SwiftyTextTable.git",
+        "state": {
+          "branch": null,
+          "revision": "c6df6cf533d120716bff38f8ff9885e1ce2a4ac3",
+          "version": "0.9.0"
+        }
+      },
+      {
+        "package": "SWXMLHash",
+        "repositoryURL": "https://github.com/drmohundro/SWXMLHash.git",
+        "state": {
+          "branch": null,
+          "revision": "a853604c9e9a83ad9954c7e3d2a565273982471f",
+          "version": "7.0.2"
+        }
+      },
+      {
+        "package": "Yams",
+        "repositoryURL": "https://github.com/jpsim/Yams.git",
+        "state": {
+          "branch": null,
+          "revision": "0d9ee7ea8c4ebd4a489ad7a73d5c6cad55d6fed3",
+          "version": "5.0.6"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -10,22 +10,30 @@ let package = Package(
             name: "WordPressUI",
             targets: [
                 "WordPressUIObjC",
-                "WordPressUI",
+                "WordPressUI"
             ]
         )
     ],
-    dependencies: [],
+    dependencies: [
+        .package(url: "https://github.com/realm/SwiftLint", from: "0.54.0")
+    ],
     targets: [
         .target(name: "WordPressUIObjC"),
         .target(
             name: "WordPressUI",
             dependencies: [
-                .target(name: "WordPressUIObjC"),
+                .target(name: "WordPressUIObjC")
+            ],
+            plugins: [
+                 .plugin(name: "SwiftLintPlugin", package: "SwiftLint")
             ]
         ),
         .testTarget(
             name: "WordPressUITests",
-            dependencies: [.target(name: "WordPressUI")]
-        ),
+            dependencies: [.target(name: "WordPressUI")],
+            plugins: [
+                 .plugin(name: "SwiftLintPlugin", package: "SwiftLint")
+            ]
+        )
     ]
 )

--- a/Sources/WordPressUI/BottomSheet/BottomSheetAnimationController.swift
+++ b/Sources/WordPressUI/BottomSheet/BottomSheetAnimationController.swift
@@ -38,7 +38,7 @@ public class BottomSheetAnimationController: NSObject, UIViewControllerAnimatedT
             }
         }
 
-        UIView.animate(withDuration: transitionDuration(using: transitionContext), animations: animationBlock, completion: { finished in
+        UIView.animate(withDuration: transitionDuration(using: transitionContext), animations: animationBlock, completion: { _ in
             transitionContext.completeTransition(!transitionContext.transitionWasCancelled)
         })
     }

--- a/Sources/WordPressUI/BottomSheet/DrawerPresentationController.swift
+++ b/Sources/WordPressUI/BottomSheet/DrawerPresentationController.swift
@@ -230,7 +230,6 @@ public class DrawerPresentationController: FancyAlertPresentationController {
         configureScrollViewInsets()
     }
 
-
     // MARK: - Internal Positions
     // Helpers to calculate the Y positions for the drawer positions
 
@@ -306,10 +305,10 @@ public class DrawerPresentationController: FancyAlertPresentationController {
         addGestures()
         observe(scrollView: presentableViewController?.scrollableView)
     }
-    
+
     /// Represents whether the view is animating to a new position
     private var isPresentedViewAnimating = false
-    
+
     /// Whether or not the presented view is anchored to the top of the screen
     private var isPresentedViewAnchored: Bool {
         if !isPresentedViewAnimating
@@ -321,14 +320,14 @@ public class DrawerPresentationController: FancyAlertPresentationController {
     }
 
     private var dragStartPoint: CGPoint?
-    
+
     /// Stores the current `contentOffset.y` for `presentableViewController.scrollableView`
     /// See `haltScrolling` and `trackScrolling` for more information.
     private var scrollViewYOffset: CGFloat = 0.0
-        
+
     /// An observer of the content offset for `presentableViewController.scrollableView`
     private var scrollObserver: NSKeyValueObservation?
-    
+
     deinit {
         scrollObserver?.invalidate()
     }
@@ -336,7 +335,7 @@ public class DrawerPresentationController: FancyAlertPresentationController {
 
 // MARK: - Dragging
 private extension DrawerPresentationController {
-    
+
     private func addGestures() {
         guard
             let presentedView = self.presentedView,
@@ -362,11 +361,11 @@ private extension DrawerPresentationController {
 
     @objc func pan(_ gesture: UIPanGestureRecognizer) {
         guard let presentedView = self.presentedView else { return }
-        
+
         let isScrolling = presentableViewController?.scrollableView?.isScrolling == true
-        
+
         guard (presentableViewController?.scrollableView?.contentOffset.y ?? 0) <= 0 || isScrolling == false else { return }
-        
+
         /// Ignore the animation once panning begins so we can immediately interact
         isPresentedViewAnimating = false
 
@@ -381,7 +380,7 @@ private extension DrawerPresentationController {
         case .changed:
             let startY = dragStartPoint?.y ?? 0
             var yTranslation = translation.y
-            
+
             /// Slows the deceleration rate
             if isScrolling && presentedView.frame.origin.y < expandedYPosition {
                 yTranslation /= 2.0
@@ -405,17 +404,17 @@ private extension DrawerPresentationController {
                 /// During scrolling, ensure yPosition doesn't extend past the expanded position
                 yPosition = max(yPosition, expandedYPosition)
             }
-            
+
             let newMargin = max(yPosition, maxY)
             setTopMargin(newMargin, animated: false)
 
         case .ended:
             /// Helper closure to prevent user transition/dismiss
-            let transition: (DrawerPosition) -> () = { pos in
+            let transition: (DrawerPosition) -> Void = { pos in
                 if allowsUserTransition || pos == .closed && allowDragToDismiss {
                     self.transition(to: pos)
                 } else {
-                    //Reset to the original position
+                    // Reset to the original position
                     self.transition(to: self.currentPosition)
                 }
             }
@@ -428,11 +427,10 @@ private extension DrawerPresentationController {
 
             // Determine how to handle flicking of the view
             if (abs(velocity) - Constants.flickVelocity) > 0 {
-                //Flick up
+                // Flick up
                 if velocity < 0 {
                     transition(.expanded)
-                }
-                else {
+                } else {
                     if position == .expanded {
                         transition(.collapsed)
                     } else {
@@ -455,7 +453,7 @@ private extension DrawerPresentationController {
 
 // MARK: - Scrolling
 private extension DrawerPresentationController {
-    
+
     /// Adds an observer for the scroll view's content offset.
     /// Track scrolling without overriding the `scrollView` delegate
     /// - Parameter scrollView: The scroll view whose content offset will be tracked.
@@ -470,13 +468,13 @@ private extension DrawerPresentationController {
             self?.didPan(on: scrollView, change: change)
         }
     }
-    
+
     /// Handles scroll view content offset changes
     /// - Parameters:
     ///   - scrollView: The scroll view whose content offset is changing.
     ///   - change: The change representing the old and new content offsets.
     func didPan(on scrollView: UIScrollView, change: NSKeyValueObservedChange<CGPoint>) {
-        
+
         guard
             !presentedViewController.isBeingDismissed,
             !presentedViewController.isBeingPresented
@@ -502,7 +500,7 @@ private extension DrawerPresentationController {
             trackScrolling(scrollView)
         }
     }
-    
+
     /// Stops scrolling behavior on `scrollView` and anchors to `scrollViewYOffset`.
     /// - Parameter scrollView: The scroll view to stop and anchor anchor
     private func haltScrolling(_ scrollView: UIScrollView) {
@@ -514,7 +512,7 @@ private extension DrawerPresentationController {
         scrollView.setContentOffset(CGPoint(x: 0, y: scrollViewYOffset), animated: false)
         scrollView.showsVerticalScrollIndicator = false
     }
-    
+
     /// Tracks and saves the y offset of `scrollView` in `scrollViewYOffset`.
     /// Used later by `haltScrolling` to adjust the scroll view to `scrollViewYOffset` to give the appearance of the sticking position.
     /// - Parameter scrollView: The scroll view to track.
@@ -533,9 +531,9 @@ private extension UIScrollView {
 
 extension DrawerPresentationController: UIGestureRecognizerDelegate {
     public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
-        
+
         guard tapGestureRecognizer == gestureRecognizer else { return true }
-        
+
         /// Shouldn't happen; should always have container & presented view when tapped
         guard
             let containerView = containerView,
@@ -551,11 +549,11 @@ extension DrawerPresentationController: UIGestureRecognizerDelegate {
         /// Do not accept the touch if inside of the presented view
         return (gestureRecognizer == tapGestureRecognizer) && isInPresentedView == false
     }
-    
+
     public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldBeRequiredToFailBy otherGestureRecognizer: UIGestureRecognizer) -> Bool {
         return false
     }
-    
+
     public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
         return otherGestureRecognizer.view == presentableViewController?.scrollableView
     }
@@ -570,7 +568,6 @@ private extension DrawerPresentationController {
             let presentedView = self.presentedView,
             let presentingView = presentingViewController.view
             else { return }
-
 
         let bottom = presentingView.safeAreaInsets.bottom
         let margin = presentedView.frame.origin.y + bottom
@@ -645,7 +642,7 @@ private extension DrawerPresentationController {
                        usingSpringWithDamping: 0.8,
                        initialSpringVelocity: 0,
                        options: [.curveEaseInOut, .allowUserInteraction],
-                       animations: animations) { [weak self] completed in
+                       animations: animations) { [weak self] _ in
             self?.isPresentedViewAnimating = false
         }
     }

--- a/Sources/WordPressUI/Constants/UIKitConstants.swift
+++ b/Sources/WordPressUI/Constants/UIKitConstants.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-
 // MARK: UIKit Constants
 //
 public class UIKitConstants {

--- a/Sources/WordPressUI/Extensions/BlockEvents/UIBarButtonItem+BlockEvents.swift
+++ b/Sources/WordPressUI/Extensions/BlockEvents/UIBarButtonItem+BlockEvents.swift
@@ -38,4 +38,3 @@ extension ControlEventBindable where Self: UIBarButtonItem {
         self.controlEventHandlers.append(handler)
     }
 }
-

--- a/Sources/WordPressUI/Extensions/CGAffineTransform+Helpers.swift
+++ b/Sources/WordPressUI/Extensions/CGAffineTransform+Helpers.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-
 // MARK: - CGAffineTransform Helpers
 //
 extension CGAffineTransform {

--- a/Sources/WordPressUI/Extensions/UIImage+Assets.swift
+++ b/Sources/WordPressUI/Extensions/UIImage+Assets.swift
@@ -12,7 +12,6 @@ extension UIImage {
         return UIImage(named: "blavatar", in: bundle, compatibleWith: nil)!
     }
 
-
     /// Returns the Default Gravatar Placeholder Image.
     ///
     @objc

--- a/Sources/WordPressUI/Extensions/UIImage+Crop.swift
+++ b/Sources/WordPressUI/Extensions/UIImage+Crop.swift
@@ -19,4 +19,3 @@ extension UIImage {
         return self
     }
 }
-

--- a/Sources/WordPressUI/Extensions/UIImageView+Blavatar.swift
+++ b/Sources/WordPressUI/Extensions/UIImageView+Blavatar.swift
@@ -20,13 +20,11 @@ public extension UIImageView {
         downloadResizedImage(from: updatedURL, pointSize: size)
     }
 
-
     /// Returns the desired Blavatar Side-Size, in pixels
     ///
     private var blavatarSize: Int {
         return blavatarSizeInPoints * Int(mainScreenScale)
     }
-
 
     /// Returns the desired Blavatar Side-Size, in points
     ///
@@ -40,13 +38,11 @@ public extension UIImageView {
         return Int(size)
     }
 
-
     /// Returns the Main Screen Scale
     ///
     private var mainScreenScale: CGFloat {
         return UIScreen.main.scale
     }
-
 
     /// Private helper structure
     ///

--- a/Sources/WordPressUI/Extensions/UIImageView+Gravatar.swift
+++ b/Sources/WordPressUI/Extensions/UIImageView+Gravatar.swift
@@ -88,7 +88,7 @@ extension UIImageView {
     ///     - animate: enable/disable fade in animation
     ///     - failure: Callback block to be invoked when an error occurs while fetching the Gravatar image
     ///
-    public func downloadGravatar(_ gravatar: Gravatar?, placeholder: UIImage, animate: Bool, failure: ((Error?) -> ())? = nil) {
+    public func downloadGravatar(_ gravatar: Gravatar?, placeholder: UIImage, animate: Bool, failure: ((Error?) -> Void)? = nil) {
         guard let gravatar = gravatar else {
             self.image = placeholder
             return
@@ -118,7 +118,6 @@ extension UIImageView {
             failure?(error)
         })
     }
-
 
     /// Sets an Image Override in both, AFNetworking's Private Cache + NSURLCache
     ///
@@ -160,7 +159,6 @@ extension UIImageView {
         }
         NotificationCenter.default.post(name: .GravatarImageUpdateNotification, object: self, userInfo: [Defaults.emailKey: email, Defaults.imageKey: image])
     }
-
 
     // MARK: - Private Helpers
 

--- a/Sources/WordPressUI/Extensions/UIImageView+Networking.swift
+++ b/Sources/WordPressUI/Extensions/UIImageView+Networking.swift
@@ -37,7 +37,7 @@ public extension UIImageView {
     ///     -   success: Closure to be executed on success.
     ///     -   failure: Closure to be executed upon failure.
     ///
-    @objc func downloadImage(from url: URL?, placeholderImage: UIImage? = nil, success: ((UIImage) -> ())? = nil, failure: ((Error?) -> ())? = nil) {
+    @objc func downloadImage(from url: URL?, placeholderImage: UIImage? = nil, success: ((UIImage) -> Void)? = nil, failure: ((Error?) -> Void)? = nil) {
         // Ideally speaking, this method should *not* receive an Optional URL. But we're doing so, for convenience.
         // If the actual URL was nil, at least we set the Placeholder Image. Capicci?
         guard let url = url else {
@@ -62,10 +62,10 @@ public extension UIImageView {
     ///     -   success: Closure to be executed on success.
     ///     -   failure: Closure to be executed upon failure.
     ///
-    @objc func downloadImage(usingRequest request: URLRequest, placeholderImage: UIImage? = nil, success: ((UIImage) -> ())? = nil, failure: ((Error?) -> ())? = nil) {
+    @objc func downloadImage(usingRequest request: URLRequest, placeholderImage: UIImage? = nil, success: ((UIImage) -> Void)? = nil, failure: ((Error?) -> Void)? = nil) {
         cancelImageDownload()
 
-        let handleSuccess = { [weak self] (image: UIImage, url: URL) in
+        let handleSuccess = { [weak self] (image: UIImage, _: URL) in
             self?.image = image
             success?(image)
         }
@@ -115,7 +115,6 @@ public extension UIImageView {
         task.resume()
     }
 
-
     /// Overrides the cached UIImage, for a given URL. This is useful for whenever we've just updated a remote resource,
     /// and we need to prevent returning the (old) cached entry.
     ///
@@ -146,7 +145,6 @@ public extension UIImageView {
 
         return request
     }
-
 
     /// Stores the current DataTask, in charge of downloading the remote Image.
     ///

--- a/Sources/WordPressUI/Extensions/UITableView+Helpers.swift
+++ b/Sources/WordPressUI/Extensions/UITableView+Helpers.swift
@@ -74,7 +74,6 @@ extension UITableView {
 
     public static let defaultFlashLength: TimeInterval = 0.7
 
-
     /// Returns true if the table view does not have any rows
     ///
     @objc public var isEmpty: Bool {

--- a/Sources/WordPressUI/Extensions/UITableViewController+Helpers.swift
+++ b/Sources/WordPressUI/Extensions/UITableViewController+Helpers.swift
@@ -18,18 +18,17 @@ extension UITableViewController {
 
         if let indexPath = tableView.indexPathForSelectedRow {
             if let coordinator = transitionCoordinator {
-                let animationBlock: (UIViewControllerTransitionCoordinatorContext?) -> () = { [unowned self] _ in
+                let animationBlock: (UIViewControllerTransitionCoordinatorContext?) -> Void = { [unowned self] _ in
                     self.tableView.deselectRow(at: indexPath, animated: true)
                 }
-                let completionBlock: (UIViewControllerTransitionCoordinatorContext?) -> () = { [unowned self] context in
+                let completionBlock: (UIViewControllerTransitionCoordinatorContext?) -> Void = { [unowned self] context in
                     if let context = context,
                         context.isCancelled {
                         self.tableView.selectRow(at: indexPath, animated: true, scrollPosition: .none)
                     }
                 }
                 coordinator.animate(alongsideTransition: animationBlock, completion: completionBlock)
-            }
-            else {
+            } else {
                 tableView.deselectRow(at: indexPath, animated: true)
             }
         }

--- a/Sources/WordPressUI/Extensions/UITextField+TextHelper.swift
+++ b/Sources/WordPressUI/Extensions/UITextField+TextHelper.swift
@@ -1,6 +1,5 @@
 import UIKit
 
-
 extension UITextField {
     public func nonNilTrimmedText() -> String {
         let trimmed = text?.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)

--- a/Sources/WordPressUI/Extensions/UIView+Animations.swift
+++ b/Sources/WordPressUI/Extensions/UIView+Animations.swift
@@ -168,7 +168,7 @@ extension UIView {
             animations(beginFrame, endFrame)
         }, completion: nil)
     }
-       
+
     /// Private Constants
     ///
     private struct Animations {

--- a/Sources/WordPressUI/Extensions/UIView+Helpers.swift
+++ b/Sources/WordPressUI/Extensions/UIView+Helpers.swift
@@ -31,7 +31,7 @@ extension UIView {
             leadingAnchor.constraint(equalTo: subview.leadingAnchor, constant: -insets.left),
             trailingAnchor.constraint(equalTo: subview.trailingAnchor, constant: insets.right),
             topAnchor.constraint(equalTo: subview.topAnchor, constant: -insets.top),
-            bottomAnchor.constraint(equalTo: subview.bottomAnchor, constant: insets.bottom),
+            bottomAnchor.constraint(equalTo: subview.bottomAnchor, constant: insets.bottom)
             ])
     }
 
@@ -40,7 +40,7 @@ extension UIView {
             layoutMarginsGuide.leadingAnchor.constraint(equalTo: subview.leadingAnchor),
             layoutMarginsGuide.trailingAnchor.constraint(equalTo: subview.trailingAnchor),
             layoutMarginsGuide.topAnchor.constraint(equalTo: subview.topAnchor),
-            layoutMarginsGuide.bottomAnchor.constraint(equalTo: subview.bottomAnchor),
+            layoutMarginsGuide.bottomAnchor.constraint(equalTo: subview.bottomAnchor)
             ])
     }
 
@@ -63,7 +63,7 @@ extension UIView {
                 safeAreaLayoutGuide.leadingAnchor.constraint(equalTo: subview.leadingAnchor, constant: -insets.left),
                 safeAreaLayoutGuide.trailingAnchor.constraint(equalTo: subview.trailingAnchor, constant: insets.right),
                 safeAreaLayoutGuide.topAnchor.constraint(equalTo: subview.topAnchor, constant: -insets.top),
-                safeAreaLayoutGuide.bottomAnchor.constraint(equalTo: subview.bottomAnchor, constant: insets.bottom),
+                safeAreaLayoutGuide.bottomAnchor.constraint(equalTo: subview.bottomAnchor, constant: insets.bottom)
                 ])
         }
     }

--- a/Sources/WordPressUI/Extensions/UIViewController+ChildViewController.swift
+++ b/Sources/WordPressUI/Extensions/UIViewController+ChildViewController.swift
@@ -16,13 +16,13 @@ extension UIViewController {
     public func remove(_ child: UIViewController) {
         child.remove()
     }
-    
+
     /// Remove the child view controller
     public func remove() {
         guard parent != nil else {
             return
         }
-        
+
         willMove(toParent: nil)
         removeFromParent()
         view.removeFromSuperview()

--- a/Sources/WordPressUI/FancyAlert/FancyAlertView.swift
+++ b/Sources/WordPressUI/FancyAlert/FancyAlertView.swift
@@ -1,7 +1,6 @@
 import Foundation
 import UIKit
 
-
 // MARK: - FancyAlertView
 //
 open class FancyAlertView: UIView {
@@ -43,13 +42,12 @@ open class FancyAlertView: UIView {
     @IBOutlet weak var buttonStackView: UIStackView!
     @IBOutlet weak var buttonWrapperView: UIView!
     @IBOutlet weak var buttonWrapperViewTopConstraint: NSLayoutConstraint?
-    
+
     /// Switch
     ///
     @IBOutlet weak var bottomSwitch: UISwitch!
     @IBOutlet weak var bottomSwitchLabel: UILabel!
     @IBOutlet weak var bottomSwitchStackView: UIStackView!
-    
 
     /// Wraps the entire view to give it a background and rounded corners
     ///
@@ -150,7 +148,7 @@ open class FancyAlertView: UIView {
             cancelButton.titleLabel?.font = newValue
         }
     }
-    
+
     /// MoreInfo: Font
     ///
     @objc public dynamic var infoFont: UIFont? {
@@ -195,7 +193,6 @@ open class FancyAlertView: UIView {
             buttonWrapperView.backgroundColor = newValue
         }
     }
-
 
     /// Switches the button ButtonStackView's layout, if needed.
     ///

--- a/Sources/WordPressUI/FancyAlert/FancyAlertViewController.swift
+++ b/Sources/WordPressUI/FancyAlert/FancyAlertViewController.swift
@@ -31,30 +31,30 @@ open class FancyAlertViewController: UIViewController {
         public typealias ButtonConfig = (title: String, handler: FancyAlertButtonHandler?)
 
         public struct SwitchConfig {
-            
+
             /// Closure representing the action of pressing the switch.
             ///
             /// - Parameters:
             ///     - controller: the fancy alert VC.
             ///     - theSwitch: the switch that received the tap.
             ///
-            public typealias Action = (_ controller: FancyAlertViewController, _ theSwitch: UISwitch) -> ()
+            public typealias Action = (_ controller: FancyAlertViewController, _ theSwitch: UISwitch) -> Void
             public typealias OptionalAction = Action?
-            
+
             /// The initial value for the switch
             let initialValue: Bool
-            
+
             /// The text shown next to the switch.
             let text: String
-            
+
             /// Action closure executed each time the switch is activated
             let action: Action?
-            
+
             /// Default initializer
             public init(initialValue: Bool,
                         text: String,
                         action: Action? = nil) {
-                
+
                 self.initialValue = initialValue
                 self.text = text
                 self.action = action
@@ -90,7 +90,7 @@ open class FancyAlertViewController: UIViewController {
 
         /// Title handler for a small 'tag' style button displayed next to the title
         let titleAccessoryButton: ButtonConfig?
-        
+
         /// Configuration for the switch at the bottom of the alert.
         let switchConfig: SwitchConfig?
 
@@ -131,7 +131,6 @@ open class FancyAlertViewController: UIViewController {
             self.dismissAction = dismissAction
         }
     }
-
 
     // MARK: - Constants
 
@@ -174,8 +173,6 @@ open class FancyAlertViewController: UIViewController {
     /// FancyAlertView Reference
     ///
     @IBOutlet private weak var alertView: FancyAlertView!
-
-
 
     /// The configuration determines the content and visibility of all UI
     /// components in the dialog. Changing this value after presenting the
@@ -245,7 +242,7 @@ open class FancyAlertViewController: UIViewController {
         alertView.updateButtonLayout()
     }
 
-    /// MARK: - View configuration
+    // MARK: - View configuration
 
     private func updateViewConfiguration() {
         guard isViewLoaded else { return }
@@ -362,15 +359,15 @@ open class FancyAlertViewController: UIViewController {
         button.setTitle(buttonConfig.title, for: .normal)
         buttonHandlers[button] = buttonConfig.handler
     }
-    
+
     private func updateBottomSwitch(with config: Config.SwitchConfig?) {
         guard let config = config else {
             alertView.bottomSwitchStackView.isHiddenInStackView = true
             return
         }
-        
+
         alertView.bottomSwitchStackView.isHiddenInStackView = false
-        
+
         alertView.bottomSwitch.setOn(config.initialValue, animated: false)
         alertView.bottomSwitch.on(.touchUpInside) { [unowned self] theSwitch in
             config.action?(self, theSwitch)
@@ -401,9 +398,9 @@ open class FancyAlertViewController: UIViewController {
     private var isImageCompact: Bool {
         return configuration?.dividerPosition == .top || isButtonless
     }
-    
+
     // MARK: - Bottom Switch
-    
+
     public func isBottomSwitchOn() -> Bool {
         return alertView.bottomSwitch.isOn
     }

--- a/Sources/WordPressUI/FancyAlert/FancyButton.swift
+++ b/Sources/WordPressUI/FancyAlert/FancyButton.swift
@@ -1,7 +1,6 @@
 import Foundation
 import UIKit
 
-
 // MARK: - FancyButton
 //
 open class FancyButton: UIButton {
@@ -13,7 +12,7 @@ open class FancyButton: UIButton {
             configureBackgrounds()
         }
     }
-    @objc public dynamic var primaryNormalBorderColor: UIColor? = nil {
+    @objc public dynamic var primaryNormalBorderColor: UIColor? {
         didSet {
             configureBackgrounds()
         }
@@ -26,7 +25,7 @@ open class FancyButton: UIButton {
             configureBackgrounds()
         }
     }
-    @objc public dynamic var primaryHighlightBorderColor: UIColor? = nil {
+    @objc public dynamic var primaryHighlightBorderColor: UIColor? {
         didSet {
             configureBackgrounds()
         }
@@ -108,7 +107,6 @@ open class FancyButton: UIButton {
         }
     }
 
-
     // MARK: - LifeCycle Methods
 
     open override func didMoveToWindow() {
@@ -120,7 +118,7 @@ open class FancyButton: UIButton {
         super.awakeFromNib()
         configureAppearance()
     }
-    
+
     open override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         configureBackgrounds()
@@ -204,7 +202,6 @@ open class FancyButton: UIButton {
         titleLabel?.textAlignment = .center
     }
 }
-
 
 // MARK: - Nested Types
 //

--- a/Sources/WordPressUI/FlingableView/FlingableViewHandler.swift
+++ b/Sources/WordPressUI/FlingableView/FlingableViewHandler.swift
@@ -34,7 +34,7 @@ open class FlingableViewHandler: NSObject {
     fileprivate var panGestureRecognizer: UIPanGestureRecognizer!
 
     // Used to restore the target view to its original position if the gesture is cancelled
-    fileprivate var initialCenter: CGPoint? = nil
+    fileprivate var initialCenter: CGPoint?
 
     /// - parameter targetView: The view that can be flung.
     @objc public init(targetView: UIView) {
@@ -66,12 +66,10 @@ open class FlingableViewHandler: NSObject {
 
             attachmentBehavior = makeAttachmentBehaviorForRecognizer(recognizer, inView: view)
             animator.addBehavior(attachmentBehavior)
-            break
-        case .changed:
+            case .changed:
             let anchor = recognizer.location(ofTouch: 0, in: referenceView)
             attachmentBehavior.anchorPoint = anchor
-            break
-        case .ended, .cancelled:
+            case .ended, .cancelled:
             animator.removeAllBehaviors()
 
             let magnitude = recognizer.magnitudeInView(referenceView)
@@ -85,7 +83,6 @@ open class FlingableViewHandler: NSObject {
 
             let pushBehavior = makePushBehaviorForRecognizer(recognizer, inView: view)
             animator.addBehavior(pushBehavior)
-            break
         default:
             break
         }

--- a/Sources/WordPressUI/Ghosts/GhostOptions.swift
+++ b/Sources/WordPressUI/Ghosts/GhostOptions.swift
@@ -1,7 +1,6 @@
 import Foundation
 import UIKit
 
-
 // MARK: - GhostOptions: Content Options.
 //
 public struct GhostOptions {
@@ -17,7 +16,6 @@ public struct GhostOptions {
     /// Indicates if an Emtpy SectionHeader should be rendered (for placeholder purposes).
     ///
     let displaysSectionHeader: Bool
-
 
     /// Designated Initializer
     ///

--- a/Sources/WordPressUI/Ghosts/GhostStyle.swift
+++ b/Sources/WordPressUI/Ghosts/GhostStyle.swift
@@ -1,7 +1,6 @@
 import Foundation
 import UIKit
 
-
 // MARK: - GhostStyle: Ghost Animation Preferences.
 //
 public struct GhostStyle {
@@ -26,14 +25,12 @@ public struct GhostStyle {
     ///
     public init(beatDuration: TimeInterval = Defaults.beatDuration,
                 beatStartColor: UIColor = Defaults.beatStartColor,
-                beatEndColor: UIColor = Defaults.beatEndColor)
-    {
+                beatEndColor: UIColor = Defaults.beatEndColor) {
         self.beatDuration = beatDuration
         self.beatStartColor = beatStartColor
         self.beatEndColor = beatEndColor
     }
 }
-
 
 // MARK: - Nested Types
 //

--- a/Sources/WordPressUI/Ghosts/Internal/GhostAnimation.swift
+++ b/Sources/WordPressUI/Ghosts/Internal/GhostAnimation.swift
@@ -2,7 +2,6 @@ import Foundation
 import QuartzCore
 import UIKit
 
-
 /// GhostAnimation: Animates a CALayer with a "Beating" animation, that interpolates from Color A to Color B.
 ///
 class GhostAnimation: CABasicAnimation {
@@ -10,7 +9,6 @@ class GhostAnimation: CABasicAnimation {
     /// Default Animation Key
     ///
     static let defaultKey = "SkeletonAnimationKey"
-
 
     /// Designated Initializer
     ///

--- a/Sources/WordPressUI/Ghosts/Internal/GhostCollectionViewHandler.swift
+++ b/Sources/WordPressUI/Ghosts/Internal/GhostCollectionViewHandler.swift
@@ -1,7 +1,6 @@
 import Foundation
 import UIKit
 
-
 /// GhostCollectionViewHandler: Encapsulates all of the methods required to setup a "Ghost UICollectionView".
 ///
 class GhostCollectionViewHandler: NSObject {
@@ -14,7 +13,6 @@ class GhostCollectionViewHandler: NSObject {
     ///
     let style: GhostStyle
 
-
     /// Designated Initializer
     ///
     init(options: GhostOptions, style: GhostStyle) {
@@ -22,7 +20,6 @@ class GhostCollectionViewHandler: NSObject {
         self.style = style
     }
 }
-
 
 /// SkeletonCollectionViewHandler: DataSource Methods
 ///
@@ -44,7 +41,6 @@ extension GhostCollectionViewHandler: UICollectionViewDataSource {
         return cell
     }
 }
-
 
 /// SkeletonCollectionViewHandler: Delegate Methods
 ///

--- a/Sources/WordPressUI/Ghosts/Internal/GhostLayer.swift
+++ b/Sources/WordPressUI/Ghosts/Internal/GhostLayer.swift
@@ -2,7 +2,6 @@ import Foundation
 import QuartzCore
 import UIKit
 
-
 /// GhostLayer: Can be inserted into a UIView instance, and reacts to its resize events.
 ///
 class GhostLayer: CALayer {
@@ -10,7 +9,6 @@ class GhostLayer: CALayer {
     /// KVO Reference Token
     ///
     private var observerToken: NSKeyValueObservation?
-
 
     /// Required Initializer
     ///
@@ -31,7 +29,6 @@ class GhostLayer: CALayer {
         anchorPoint = .zero
     }
 
-
     /// Inserts the receiver into the target view's Layer Hierarchy.
     ///
     func insert(into view: UIView) {
@@ -47,7 +44,6 @@ class GhostLayer: CALayer {
     }
 }
 
-
 /// Private Methods
 ///
 private extension GhostLayer {
@@ -60,7 +56,6 @@ private extension GhostLayer {
         }
     }
 }
-
 
 /// Animations API
 ///

--- a/Sources/WordPressUI/Ghosts/Internal/GhostTableViewHandler.swift
+++ b/Sources/WordPressUI/Ghosts/Internal/GhostTableViewHandler.swift
@@ -1,7 +1,6 @@
 import Foundation
 import UIKit
 
-
 /// GhostTableViewHandler: Encapsulates all of the methods required to setup a "Ghost UICollectionView".
 ///
 class GhostTableViewHandler: NSObject {
@@ -14,7 +13,6 @@ class GhostTableViewHandler: NSObject {
     ///
     let style: GhostStyle
 
-
     /// Designated Initializer
     ///
     init(options: GhostOptions, style: GhostStyle) {
@@ -22,7 +20,6 @@ class GhostTableViewHandler: NSObject {
         self.style = style
     }
 }
-
 
 /// GhostTableViewHandler: DataSource Methods
 ///
@@ -47,7 +44,6 @@ extension GhostTableViewHandler: UITableViewDataSource {
         return cell
     }
 }
-
 
 /// GhostTableViewHandler: Delegate Methods
 ///

--- a/Sources/WordPressUI/Ghosts/Internal/UIView+InnerGhost.swift
+++ b/Sources/WordPressUI/Ghosts/Internal/UIView+InnerGhost.swift
@@ -1,7 +1,6 @@
 import Foundation
 import UIKit
 
-
 /// UIView: Skeletonizer Public API
 ///
 extension UIView {
@@ -44,7 +43,6 @@ extension UIView {
     }
 }
 
-
 /// Private Methods
 ///
 private extension UIView {
@@ -65,7 +63,7 @@ private extension UIView {
 
     /// Enumerates all of the receiver's Leaf Views.
     ///
-    func enumerateGhostableLeafViews(callback: (UIView) -> ()) {
+    func enumerateGhostableLeafViews(callback: (UIView) -> Void) {
         guard !isGhostableDisabled && !isPrivateUIKitInstance else {
             return
         }

--- a/Sources/WordPressUI/Ghosts/UICollectionView+Ghost.swift
+++ b/Sources/WordPressUI/Ghosts/UICollectionView+Ghost.swift
@@ -1,7 +1,6 @@
 import Foundation
 import UIKit
 
-
 // MARK: - Skeleton UICollectionView Methods
 //
 extension UICollectionView {
@@ -41,7 +40,6 @@ extension UICollectionView {
     }
 }
 
-
 // MARK: - Private Methods
 //
 private extension UICollectionView {
@@ -80,7 +78,6 @@ private extension UICollectionView {
         initialAllowsSelection = nil
     }
 }
-
 
 // MARK: - Private "Associated" Properties
 //
@@ -130,7 +127,6 @@ private extension UICollectionView {
         }
     }
 }
-
 
 // MARK: - Nested Types
 //

--- a/Sources/WordPressUI/Ghosts/UITableView+Ghost.swift
+++ b/Sources/WordPressUI/Ghosts/UITableView+Ghost.swift
@@ -1,7 +1,6 @@
 import Foundation
 import UIKit
 
-
 // MARK: - Skeleton UITableView Methods
 //
 extension UITableView {
@@ -41,7 +40,6 @@ extension UITableView {
     }
 }
 
-
 // MARK: - Private Methods
 //
 private extension UITableView {
@@ -80,7 +78,6 @@ private extension UITableView {
         initialAllowsSelection = nil
     }
 }
-
 
 // MARK: - Private "Associated" Properties
 //
@@ -130,7 +127,6 @@ private extension UITableView {
         }
     }
 }
-
 
 // MARK: - Nested Types
 //

--- a/Sources/WordPressUI/Ghosts/UIView+Ghost.swift
+++ b/Sources/WordPressUI/Ghosts/UIView+Ghost.swift
@@ -1,7 +1,6 @@
 import Foundation
 import UIKit
 
-
 // MARK: - Ghost Animations API
 //
 extension UIView {

--- a/Tests/WordPressUITests/Extensions/UIViewControllerHelperTest.swift
+++ b/Tests/WordPressUITests/Extensions/UIViewControllerHelperTest.swift
@@ -1,11 +1,9 @@
 import XCTest
 @testable import WordPressUI
 
-
 class UIViewControllerHelperTest: XCTestCase {
     let vca = UIViewController()
     let vcb = UIViewController()
-
 
     func testAddChildViewController() {
         vca.add(vcb)

--- a/Tests/WordPressUITests/Ghosts/UITableView+GhostTests.swift
+++ b/Tests/WordPressUITests/Ghosts/UITableView+GhostTests.swift
@@ -9,7 +9,7 @@ class UITableViewGhostTests: XCTestCase {
         tableView.displayGhostContent(options: GhostOptions(reuseIdentifier: "ghost", rowsPerSection: [1]), style: .default)
 
         tableView.dataSource?.tableView(tableView, cellForRowAt: IndexPath(row: 0, section: 0))
-        
+
         XCTAssertTrue(GhostMockCell.willStartGhostAnimationCalled)
     }
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -2,6 +2,8 @@
 
 default_platform(:ios)
 
+SWIFTLINT_PLUGIN_VALIDATION_BYPASS_XCARGS = '-skipPackagePluginValidation -skipMacroValidation'
+
 platform :ios do
   desc 'Builds the project and runs tests'
   lane :test do
@@ -11,7 +13,8 @@ platform :ios do
       device: 'iPhone 14',
       prelaunch_simulator: true,
       buildlog_path: File.join(__dir__, '.build', 'logs'),
-      derived_data_path: File.join(__dir__, '.build', 'derived-data')
+      derived_data_path: File.join(__dir__, '.build', 'derived-data'),
+      xcargs: SWIFTLINT_PLUGIN_VALIDATION_BYPASS_XCARGS
     )
   end
 end


### PR DESCRIPTION
### Description

This PR sets up SwiftLint as a SPM plugin and runs it on CI using the command `run-swiftlint`.

The main changes:
- Adding the `.swiftlint.yml` file with the rules currently being checked and defining the SwiftLint version to use
- Usage of the `run-swiftlint` command from `a8c-ci-toolkit-buildkite-plugin` in a new Buildkite step.
- Adding SwiftLint as a SPM dependency and plugin
- Fixing the currently found violations in the codebase


### Testing Details

Make sure CI is 🟢


---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
