### PR TITLE
Implementing changes in Gravatar SDK

### DIFF
--- a/Sources/WordPressUI/Extensions/Gravatar/Gravatar.swift
+++ b/Sources/WordPressUI/Extensions/Gravatar/Gravatar.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Helper Enum that specifies all of the available Gravatar Image Ratings
 /// TODO: Convert into a pure Swift String Enum. It's done this way to maintain ObjC Compatibility
 ///
-@available(*, deprecated, message: "Use `GravatarRating` from the Gravatar module.")
+@available(*, deprecated, message: "Use `ImageRating`")
 @objc
 public enum GravatarRatings: Int {
     case g

--- a/Sources/WordPressUI/Extensions/Gravatar/GravatarURL+Util.swift
+++ b/Sources/WordPressUI/Extensions/Gravatar/GravatarURL+Util.swift
@@ -12,13 +12,13 @@ extension GravatarURL {
     /// - Returns: Gravatar URL.
     public static func url(for email: String,
                            preferredSize: ImageSize? = nil,
-                           gravatarRating: GravatarRating? = nil,
+                           gravatarRating: ImageRating? = nil,
                            defaultImageOption: DefaultImageOption? = .fileNotFound) -> URL? {
         return GravatarURL.gravatarUrl(with: email,
                                        // TODO: Passing GravatarDefaults.imageSize to keep the previous default.
                                        // But ideally this should be passed explicitly.
                                        options: .init(preferredSize: preferredSize ?? .pixels(GravatarDefaults.imageSize),
-                                                      gravatarRating: gravatarRating,
+                                                      rating: gravatarRating,
                                                       defaultImage: defaultImageOption))
     }
 }

--- a/Sources/WordPressUI/Extensions/UIImageView+Gravatar.swift
+++ b/Sources/WordPressUI/Extensions/UIImageView+Gravatar.swift
@@ -1,6 +1,7 @@
 import Foundation
 import UIKit
 import Gravatar
+@_exported import enum Gravatar.ImageRating
 
 #if SWIFT_PACKAGE
 import WordPressUIObjC
@@ -19,28 +20,42 @@ private class GravatarNotificationWrapper {
     }
 }
 
+// TODO: Convenience intermediate enum for Objc compatibility. Remove when Objc compatibility is not needed.
+@objc(GravatarRating)
+/// Gravatar Image Ratings for Objc compatibility.
+public enum ObjcGravatarRating: Int {
+    case g
+    case pg
+    case r
+    case x
+
+    fileprivate func map() -> ImageRating {
+        switch self {
+        case .g: .g
+        case .pg: .pg
+        case .r: .r
+        case .x: .x
+        }
+    }
+}
+
+
 /// UIImageView Helper Methods that allow us to download a Gravatar, given the User's Email
 ///
 extension UIImageView {
-
-    /// Downloads and sets the User's Gravatar, given his email.
-    /// TODO: This is a convenience method. Please, remove once all of the code has been migrated over to Swift.
-    ///
-    /// - Parameters:
-    ///   - email: The user's email
-    ///   - gravatarRating: Expected image rating
-    @objc
-    public func downloadGravatar(for email: String, gravatarRating: GravatarRating) {
-        downloadGravatar(for: email, gravatarRating: gravatarRating, placeholderImage: .gravatarPlaceholderImage)
+    // TODO: Remove when Objc compatibility is not needed.
+    @objc(downloadGravatarFor:gravatarRating:)
+    /// Re-declaration for Objc compatibility
+    public func objc_downloadGravatar(for email: String, gravatarRating: ObjcGravatarRating) {
+        downloadGravatar(for: email, gravatarRating: gravatarRating.map(), placeholderImage: .gravatarPlaceholderImage)
     }
-    
-    
+
     /// Downloads and sets the User's Gravatar, given his email.
     /// - Parameters:
     ///   - email: The user's email
     ///   - gravatarRating: Expected image rating
     ///   - placeholderImage: Image to be used as Placeholder
-    public func downloadGravatar(for email: String, gravatarRating: GravatarRating = .g, placeholderImage: UIImage = .gravatarPlaceholderImage) {
+    public func downloadGravatar(for email: String, gravatarRating: ImageRating = .g, placeholderImage: UIImage = .gravatarPlaceholderImage) {
         let gravatarURL = GravatarURL.url(for: email, preferredSize: .pixels(gravatarDefaultSize()), gravatarRating: gravatarRating)
         listenForGravatarChanges(forEmail: email)
         downloadGravatar(fullURL: gravatarURL, placeholder: placeholderImage, animate: false, failure: nil)
@@ -66,7 +81,7 @@ extension UIImageView {
     ///     - rating: expected image rating
     ///     - placeholderImage: Image to be used as Placeholder
     ///
-    @available(*, deprecated, message: "Use downloadGravatar(for email: String, gravatarRating: GravatarRating = .g, placeholderImage: UIImage = .gravatarPlaceholderImage)")
+    @available(*, deprecated, message: "Use downloadGravatar(for email: String, gravatarRating: ImageRating = .g, placeholderImage: UIImage = .gravatarPlaceholderImage)")
     @objc
     public func downloadGravatarWithEmail(_ email: String, rating: GravatarRatings = .default, placeholderImage: UIImage = .gravatarPlaceholderImage) {
         let gravatarURL = Gravatar.gravatarUrl(for: email, size: gravatarDefaultSize(), rating: rating)


### PR DESCRIPTION
Implementing changes from https://github.com/Automattic/Gravatar-SDK-iOS/pull/83

`ImageRating` is now pure Swift enum.

WPiOS still calls `[downloadGravatarFor:gravatarRating:]` from Objc, so we need to keep compatibility.

I thought about moving `Objc` compatibility to WPiOS, and keep `WPUI` simpler, in this way we avoid exporting two different enums for Ratings. Finally I decided to keep it here in order to avoid making WPiOS merge bigger.

We can think about this in the future.

To test:
- Check out `GravatarSDK` at https://github.com/Automattic/Gravatar-SDK-iOS/pull/83
- Build the Jetpack
- Go to the Me section
  - Check that the user avatar is shown.
---

- [ ] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
