### PR TITLE
Rename defaultImage as defaultImageOption

### DIFF
--- a/Sources/WordPressUI/Extensions/Gravatar/GravatarURL+Util.swift
+++ b/Sources/WordPressUI/Extensions/Gravatar/GravatarURL+Util.swift
@@ -19,6 +19,6 @@ extension GravatarURL {
                                        // But ideally this should be passed explicitly.
                                        options: .init(preferredSize: preferredSize ?? .pixels(GravatarDefaults.imageSize),
                                                       rating: gravatarRating,
-                                                      defaultImage: defaultImageOption))
+                                                      defaultImageOption: defaultImageOption))
     }
 }


### PR DESCRIPTION
Rename defaultImage as defaultImageOption

Gravatar PR: https://github.com/Automattic/Gravatar-SDK-iOS/pull/100

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
