### PR TITLE
Update GravatarImageSettingOption as ImageSettingOption

### DIFF
--- a/Sources/WordPressUI/Extensions/UIImageView+Gravatar.swift
+++ b/Sources/WordPressUI/Extensions/UIImageView+Gravatar.swift
@@ -148,7 +148,7 @@ extension UIImageView {
 
     private func downloadGravatar(fullURL: URL?, placeholder: UIImage, animate: Bool, failure: ((Error?) -> ())? = nil) {
         self.gravatar.cancelImageDownload()
-        let options: [GravatarImageSettingOption] = [.imageCache(ImageCache.shared)]
+        let options: [ImageSettingOption] = [.imageCache(ImageCache.shared)]
         self.gravatar.setImage(with: fullURL,
                                placeholder: placeholder,
                                options: options) { [weak self] result in


### PR DESCRIPTION
Updates GravatarImageSettingOption as ImageSettingOption. 

Gravatar SDK PR: https://github.com/Automattic/Gravatar-SDK-iOS/pull/101

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
