### PR TITLE
[Gravatar] Update image rating name

### DIFF
--- a/Sources/WordPressUI/Extensions/Gravatar/GravatarURL+Util.swift
+++ b/Sources/WordPressUI/Extensions/Gravatar/GravatarURL+Util.swift
@@ -12,7 +12,7 @@ extension GravatarURL {
     /// - Returns: Gravatar URL.
     public static func url(for email: String,
                            preferredSize: ImageSize? = nil,
-                           gravatarRating: ImageRating? = nil,
+                           gravatarRating: Rating? = nil,
                            defaultImageOption: DefaultImageOption? = .fileNotFound) -> URL? {
         return GravatarURL.gravatarUrl(with: email,
                                        // TODO: Passing GravatarDefaults.imageSize to keep the previous default.

--- a/Sources/WordPressUI/Extensions/UIImageView+Gravatar.swift
+++ b/Sources/WordPressUI/Extensions/UIImageView+Gravatar.swift
@@ -1,7 +1,9 @@
 import Foundation
 import UIKit
 import Gravatar
-@_exported import enum Gravatar.ImageRating
+import enum Gravatar.Rating
+
+public typealias ImageRating = Rating
 
 #if SWIFT_PACKAGE
 import WordPressUIObjC
@@ -29,11 +31,11 @@ public enum ObjcGravatarRating: Int {
     case r
     case x
 
-    fileprivate func map() -> ImageRating {
+    fileprivate func map() -> Rating {
         switch self {
-        case .g: .g
-        case .pg: .pg
-        case .r: .r
+        case .g: .general
+        case .pg: .parentalGuidance
+        case .r: .restricted
         case .x: .x
         }
     }
@@ -55,7 +57,7 @@ extension UIImageView {
     ///   - email: The user's email
     ///   - gravatarRating: Expected image rating
     ///   - placeholderImage: Image to be used as Placeholder
-    public func downloadGravatar(for email: String, gravatarRating: ImageRating = .g, placeholderImage: UIImage = .gravatarPlaceholderImage) {
+    public func downloadGravatar(for email: String, gravatarRating: ImageRating = .general, placeholderImage: UIImage = .gravatarPlaceholderImage) {
         let gravatarURL = GravatarURL.url(for: email, preferredSize: .pixels(gravatarDefaultSize()), gravatarRating: gravatarRating)
         listenForGravatarChanges(forEmail: email)
         downloadGravatar(fullURL: gravatarURL, placeholder: placeholderImage, animate: false, failure: nil)


### PR DESCRIPTION
Implementing changes from https://github.com/Automattic/Gravatar-SDK-iOS/pull/119

This PR renames `Gravatar.ImageRating` to `Gravatar.Rating`.

---

- [ ] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
