### PR TITLE
[Gravatar] Replacing `GravatarURL` with `AvatarURL`

### DIFF
--- a/Sources/WordPressUI/Extensions/Gravatar/GravatarURL+Util.swift
+++ b/Sources/WordPressUI/Extensions/Gravatar/GravatarURL+Util.swift
@@ -1,8 +1,7 @@
 import Foundation
 import Gravatar
 
-extension GravatarURL {
-    
+extension AvatarURL {
     /// Creates a Gravatar URL. This is the new version of the deprecated method: `Gravatar.gravatarUrl(for:defaultImage:size:rating:)`
     /// - Parameters:
     ///   - email: The user's email
@@ -14,11 +13,15 @@ extension GravatarURL {
                            preferredSize: ImageSize? = nil,
                            gravatarRating: Rating? = nil,
                            defaultImageOption: DefaultImageOption? = .fileNotFound) -> URL? {
-        return GravatarURL.gravatarUrl(with: email,
-                                       // TODO: Passing GravatarDefaults.imageSize to keep the previous default.
-                                       // But ideally this should be passed explicitly.
-                                       options: .init(preferredSize: preferredSize ?? .pixels(GravatarDefaults.imageSize),
-                                                      rating: gravatarRating,
-                                                      defaultImageOption: defaultImageOption))
+        AvatarURL(
+            email: email,
+            // TODO: Passing GravatarDefaults.imageSize to keep the previous default.
+            // But ideally this should be passed explicitly.
+            options: .init(
+                preferredSize: preferredSize ?? .pixels(GravatarDefaults.imageSize),
+                rating: gravatarRating,
+                defaultImageOption: defaultImageOption
+            )
+        )?.url
     }
 }

--- a/Sources/WordPressUI/Extensions/Gravatar/GravatarURL+Util.swift
+++ b/Sources/WordPressUI/Extensions/Gravatar/GravatarURL+Util.swift
@@ -12,7 +12,7 @@ extension AvatarURL {
     public static func url(for email: String,
                            preferredSize: ImageSize? = nil,
                            gravatarRating: Rating? = nil,
-                           defaultImageOption: DefaultImageOption? = .fileNotFound) -> URL? {
+                           defaultAvatarOption: DefaultAvatarOption? = .status404) -> URL? {
         AvatarURL(
             email: email,
             // TODO: Passing GravatarDefaults.imageSize to keep the previous default.
@@ -23,4 +23,5 @@ extension AvatarURL {
                 defaultAvatarOption: defaultAvatarOption
             )
         )?.url
+    }
 }

--- a/Sources/WordPressUI/Extensions/UIImageView+Gravatar.swift
+++ b/Sources/WordPressUI/Extensions/UIImageView+Gravatar.swift
@@ -2,8 +2,22 @@ import Foundation
 import UIKit
 import Gravatar
 import enum Gravatar.Rating
+@_exported import struct Gravatar.AvatarURL
 
 public typealias ImageRating = Rating
+
+@available(*, deprecated, renamed: "AvatarURL")
+public typealias GravatarURL = AvatarURL
+
+extension GravatarURL {
+    public init?(_ url: URL) {
+        self.init(url: url)
+    }
+
+    public var canonicalURL: URL {
+        self.canonicalUrl
+    }
+}
 
 #if SWIFT_PACKAGE
 import WordPressUIObjC
@@ -144,7 +158,7 @@ extension UIImageView {
         layoutIfNeeded()
 
         let size = Int(ceil(frame.width * UIScreen.main.scale))
-        let url = gravatar.url(with: .init(preferredSize: .pixels(size)))
+        let url = gravatar.replacing(options: .init(preferredSize: .pixels(size)))?.url
         downloadGravatar(fullURL: url, placeholder: placeholder, animate: animate, failure: failure)
     }
 


### PR DESCRIPTION
closes: https://github.com/Automattic/Gravatar-SDK-iOS/issues/110
Gravatar PR: https://github.com/Automattic/Gravatar-SDK-iOS/pull/128

Small PR to implement the rename of `GravatarURL` to `AvatarURL`.

To test:
- Checkout: https://github.com/Automattic/Gravatar-SDK-iOS/pull/128
- Checkout this branch.
- Build and smoke-test WPiOS on `task/gravatar-integration` branch.

**Note:** currently WPiOS - `task/gravatar-integration` pod file is broken.
For a fast fix, remove `, :testspecs => ['Tests']` from the podfile.

```
-  pod 'Gravatar', path: '../Gravatar-SDK-iOS', :testspecs => ['Tests']
+  pod 'Gravatar', path: '../Gravatar-SDK-iOS'
```

---

- [ ] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
