### PR TITLE
[Gravatar] Use new Identifier type

### DIFF
--- a/Sources/WordPressUI/Extensions/Gravatar/GravatarURL+Util.swift
+++ b/Sources/WordPressUI/Extensions/Gravatar/GravatarURL+Util.swift
@@ -14,7 +14,7 @@ extension AvatarURL {
                            gravatarRating: Rating? = nil,
                            defaultAvatarOption: DefaultAvatarOption? = .status404) -> URL? {
         AvatarURL(
-            email: email,
+            with: .email(email),
             // TODO: Passing GravatarDefaults.imageSize to keep the previous default.
             // But ideally this should be passed explicitly.
             options: .init(


### PR DESCRIPTION
---
Using the new Identifier types in the Gravatar SDK

Required for https://github.com/wordpress-mobile/WordPress-iOS/pull/22907

Testing will be performed as part of that PR.

- [ ] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
